### PR TITLE
Enable build on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+build: off
+
+install:
+  - curl -OL https://s3.amazonaws.com/rebar3/rebar3
+
+test_script:
+  - escript ./rebar3 do compile,eunit,dialyzer
+
+deploy: false


### PR DESCRIPTION
Hello @Licenser !

In erlang-lager/lager#509 I'm fixing `lager` to run correctly on Windows. I prepared #2 on Windows, actually, and would like to contribute a configuration file to run `cuttlefish` builds on Windows.

Once merged, someone in the Kyorai org will have to create an AppVeyor account and enable the build. When logged in to AppVeyor using my GitHub credentials, I don't see any repos listed from Kyorai, presumably because I am not a member of that org.

You can see AppVeyor builds of my fork [here](https://ci.appveyor.com/project/lukebakken/cuttlefish)