### PR TITLE
Allow inclusion of other .conf files

### DIFF
--- a/src/conf_parse.erl
+++ b/src/conf_parse.erl
@@ -20,6 +20,8 @@
 %% conf_parse: for all your .conf parsing needs.
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/conf_parse.erl
+++ b/src/conf_parse.erl
@@ -20,7 +20,6 @@
 %% conf_parse: for all your .conf parsing needs.
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
-%% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -92,6 +91,20 @@ file_test() ->
         ], Conf),
     ok.
 
+included_file_test() ->
+    Conf = conf_parse:file("test/include_file.conf"),
+    ?assertEqual([
+            {include,<<"riak.conf">>}
+        ], Conf),
+    ok.
+
+included_dir_test() ->
+    Conf = conf_parse:file("test/include_dir.conf"),
+    ?assertEqual([
+            {include,<<"conf.d/*.conf">>}
+        ], Conf),
+    ok.
+
 utf8_test() ->
     Conf = conf_parse:parse("setting = thing" ++ [338] ++ "\n"),
     ?assertEqual([{["setting"],
@@ -143,7 +156,7 @@ parse(Input) when is_binary(Input) ->
 
 -spec 'line'(input(), index()) -> parse_result().
 'line'(Input, Index) ->
-  p(Input, Index, 'line', fun(I,D) -> (p_choose([p_seq([p_choose([fun 'setting'/2, fun 'comment'/2, p_one_or_more(fun 'ws'/2)]), p_choose([fun 'crlf'/2, fun 'eof'/2])]), fun 'crlf'/2]))(I,D) end, fun(Node, _Idx) ->
+  p(Input, Index, 'line', fun(I,D) -> (p_choose([p_seq([p_choose([fun 'setting'/2, fun 'include'/2, fun 'comment'/2, p_one_or_more(fun 'ws'/2)]), p_choose([fun 'crlf'/2, fun 'eof'/2])]), fun 'crlf'/2]))(I,D) end, fun(Node, _Idx) ->
     case Node of
         [ Line, _EOL ] -> Line;
         Line -> Line
@@ -178,6 +191,19 @@ parse(Input) when is_binary(Input) ->
 -spec 'comment'(input(), index()) -> parse_result().
 'comment'(Input, Index) ->
   p(Input, Index, 'comment', fun(I,D) -> (p_seq([p_zero_or_more(fun 'ws'/2), p_string(<<"#">>), p_zero_or_more(p_seq([p_not(fun 'crlf'/2), p_anything()]))]))(I,D) end, fun(_Node, _Idx) ->comment end).
+
+-spec 'include'(input(), index()) -> parse_result().
+'include'(Input, Index) ->
+  p(Input, Index, 'include', fun(I,D) -> (p_seq([p_zero_or_more(fun 'ws'/2), p_string(<<"include">>), p_zero_or_more(fun 'ws'/2), fun 'included_file_or_dir'/2, p_optional(fun 'comment'/2)]))(I,D) end, fun(Node, _Idx) ->
+    [_, _Include, _, Included, _] = Node,
+    {include, Included}
+ end).
+
+-spec 'included_file_or_dir'(input(), index()) -> parse_result().
+'included_file_or_dir'(Input, Index) ->
+  p(Input, Index, 'included_file_or_dir', fun(I,D) -> (p_one_or_more(p_charclass(<<"[A-Za-z0-9-\_\.\*\\/]">>)))(I,D) end, fun(Node, _Idx) ->
+    unicode:characters_to_binary(Node, utf8, latin1)
+ end).
 
 -spec 'word'(input(), index()) -> parse_result().
 'word'(Input, Index) ->

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -44,9 +44,9 @@ config <- line* %{
     [ L || L <- Node, is_setting(L) ]
 %};
 
-%% Lines are actual settings, comments, or horizontal whitespace,
+%% Lines are actual settings, includes, comments, or horizontal whitespace,
 %% terminated by an end-of-line or end-of-file.
-line <- ((setting / comment / ws+) (crlf / eof)) / crlf %{
+line <- ((setting / include / comment / ws+) (crlf / eof)) / crlf %{
     case Node of
         [ Line, _EOL ] -> Line;
         Line -> Line
@@ -79,6 +79,16 @@ value <- (!((ws* crlf) / comment) .)+ %{
 %% A comment is any line that begins with a # sign, leading whitespace
 %% allowed.
 comment <- ws* "#" (!crlf .)* `comment`;
+
+%% An include is a line that begins with 'include' and something.
+include <- ws* "include" ws* included_file_or_dir comment? %{
+    [_, _Include, _, Included, _] = Node,
+    {include, Included}
+%};
+
+included_file_or_dir <- [A-Za-z0-9-\_\.\*\/]+ %{
+    unicode:characters_to_binary(Node, utf8, latin1)
+%};
 
 %% A word is one or more of letters, numbers and dashes or
 %% underscores.
@@ -172,6 +182,20 @@ file_test() ->
             {["log","syslog"],"on"},
             {["listener","http","internal"],"127.0.0.1:8098"},
             {["listener","http","external"],"10.0.0.1:80"}
+        ], Conf),
+    ok.
+
+included_file_test() ->
+    Conf = conf_parse:file("test/include_file.conf"),
+    ?assertEqual([
+            {include,<<"riak.conf">>}
+        ], Conf),
+    ok.
+
+included_dir_test() ->
+    Conf = conf_parse:file("test/include_dir.conf"),
+    ?assertEqual([
+            {include,<<"conf.d/*.conf">>}
         ], Conf),
     ok.
 

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -4,6 +4,7 @@
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
 %% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -114,6 +115,8 @@ ws <- [ \t]+ `ws`;
 %% conf_parse: for all your .conf parsing needs.
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -113,6 +113,12 @@ generate_file(Mappings, Filename) ->
     _ = [ begin
           io:format(S, "~s~n", [lists:flatten(Line)])
       end || Line <- ConfFileLines],
+    % add an include directive at the end that will allow 
+    % other conf files in `conf.d` and have them get picked up
+    % in order to override settings
+    % example use case is a k8s configMap that is mapped as a file
+    % to conf.d/erlang_vm.conf
+    io:format(S, "include conf.d/*.conf~n~n", []),
     _ = file:close(S),
     ok.
 

--- a/test/conf.d/dir.d/riak.conf
+++ b/test/conf.d/dir.d/riak.conf
@@ -1,0 +1,2 @@
+log.console.file = /var/log/console.log
+rogue.option = 42

--- a/test/conf.d/riak.conf
+++ b/test/conf.d/riak.conf
@@ -1,0 +1,5 @@
+ring_size = 5 # we want a smaller ring size
+anti_entropy = debug
+log.error.file = /var/log/error.log
+listener.http.internal = 127.0.0.1:8098
+listener.http.external = 10.0.0.1:80

--- a/test/conf.d/riak2.conf
+++ b/test/conf.d/riak2.conf
@@ -1,0 +1,3 @@
+log.syslog = off
+
+include dir.d/riak.conf

--- a/test/include_dir.conf
+++ b/test/include_dir.conf
@@ -1,0 +1,1 @@
+include conf.d/*.conf

--- a/test/include_file.conf
+++ b/test/include_file.conf
@@ -1,0 +1,1 @@
+include riak.conf


### PR DESCRIPTION
Through the `include` directive one can either include
a single .conf file or many with glob patterns, eg.:
    include a_file.conf
    include many_files_dir/*.conf