### PR TITLE
Re-arrange some tests

### DIFF
--- a/test/cuttlefish_escript_tests.erl
+++ b/test/cuttlefish_escript_tests.erl
@@ -1,4 +1,4 @@
--module(cuttlefish_escript_test).
+-module(cuttlefish_escript_tests).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 

--- a/test/cuttlefish_integration_tests.erl
+++ b/test/cuttlefish_integration_tests.erl
@@ -1,4 +1,4 @@
--module(cuttlefish_integration_test).
+-module(cuttlefish_integration_tests).
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -43,21 +43,6 @@ breaks_on_fuzzy_and_strict_match_test() ->
     Schema = cuttlefish_schema:file("test/riak.schema"),
     Conf = [{["listener", "protobuf", "$name"], "127.0.0.1:8087"}],
     ?assertMatch({error, add_defaults, _}, cuttlefish_generator:map(Schema, Conf)),
-    ok.
-
-breaks_on_rhs_not_found_test() ->
-    Schema = cuttlefish_schema:file("test/riak.schema"),
-    Conf = [{["ring", "state_dir"], "$(tyktorp)/ring"}],
-    ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
-    ok.
-
-breaks_on_rhs_infinite_loop_test() ->
-    Schema = cuttlefish_schema:file("test/riak.schema"),
-    Conf = [
-            {["ring", "state_dir"], "$(platform_data_dir)/ring"},
-            {["platform_data_dir"], "$(ring.state_dir)/data"}
-           ],
-    ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_bad_enum_test() ->

--- a/test/cuttlefish_nested_schema_tests.erl
+++ b/test/cuttlefish_nested_schema_tests.erl
@@ -1,4 +1,4 @@
--module(cuttlefish_nested_schema_test).
+-module(cuttlefish_nested_schema_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/test/cuttlefish_subs_integration_tests.erl
+++ b/test/cuttlefish_subs_integration_tests.erl
@@ -1,0 +1,35 @@
+-module(cuttlefish_subs_integration_tests).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+basic_rhs_subs_1_test() ->
+  Schema = cuttlefish_schema:file("test/example1.schema"),
+  Conf = [
+    {["example1", "ab"], "ab-ab"},
+    {["example1", "cd"], "$(example1.ab)"}
+  ],
+  Generated = cuttlefish_generator:map(Schema, Conf),
+  ?assertEqual([
+    {example1, [
+      {cd, "ab-ab"},
+      {ab, "ab-ab"}
+    ]}
+  ], Generated),
+  ok.
+
+
+breaks_on_rhs_not_found_test() ->
+  Schema = cuttlefish_schema:file("test/riak.schema"),
+  Conf = [{["ring", "state_dir"], "$(tyktorp)/ring"}],
+  ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
+  ok.
+
+breaks_on_rhs_infinite_loop_test() ->
+  Schema = cuttlefish_schema:file("test/riak.schema"),
+  Conf = [
+          {["ring", "state_dir"], "$(platform_data_dir)/ring"},
+          {["platform_data_dir"], "$(ring.state_dir)/data"}
+         ],
+  ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
+  ok.

--- a/test/example1.schema
+++ b/test/example1.schema
@@ -1,0 +1,7 @@
+{mapping, "example1.ab", "example1.ab", [
+  {datatype, [string]}
+]}.
+
+{mapping, "example1.cd", "example1.cd", [
+  {datatype, [string]}
+]}.


### PR DESCRIPTION
There are no functional changes in this PR.

The changes to tests are the following.

 * Some suite names ended in "test" and others in "tests", let's use "tests" across the board since there are multiple tests per suite
 * RHS substitution tests now have their own suite because it is a pretty isolated feature
 * Some in-module EUnit tests were left alone because they depend on internal functions and, perhaps, that's exactly why they were added as "in-module" EUnit tests
 * RHS substitution tests did not really have a happy path case, so I've added one