### PR TITLE
New data type: tagged string

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -233,6 +233,7 @@ pretty_datatype({duration, _}) -> "a time duration with units, e.g. '10s' for 10
 pretty_datatype(bytesize) -> "a byte size with units, e.g. 10GB";
 pretty_datatype({integer, I}) -> "the integer " ++ integer_to_list(I);
 pretty_datatype({string, S}) -> "the text \"" ++ S ++ "\"";
+pretty_datatype({tagged_string, {Tag, String}}) -> "the text \"" ++ String ++ "\"" ++ " tagged as \"" ++ Tag ++ "\"";
 pretty_datatype({atom, A}) -> "the text \"" ++ atom_to_list(A) ++ "\"";
 pretty_datatype({ip, {IP, Port}}) -> ?FMT("the address ~ts:~tp", [IP, Port]);
 pretty_datatype({domain_socket, {local, Path, Port}}) ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -77,7 +77,7 @@ parse_and_command(Args) ->
 main(Args) ->
     {Command, ParsedArgs, Extra} = parse_and_command(Args),
 
-    SuggestedLogLevel = list_to_atom(proplists:get_value(log_level, ParsedArgs)),
+    SuggestedLogLevel = list_to_atom(proplists:get_value(log_level, ParsedArgs, "notice")),
     LogLevel = case lists:member(SuggestedLogLevel, [debug, info, notice, warning, error, critical, alert, emergency]) of
         true -> SuggestedLogLevel;
         _ -> notice

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -559,7 +559,8 @@ transform_supported_type(DT, Value) ->
         {error, Message} -> {error, Message};
         NewValue -> {ok, NewValue}
     catch
-        Class:Error ->
+        Class:Error:_Stacktrace ->
+            %% io:format("Failed to transform a type. Stacktrace: ~p~n", [Stacktrace]),
             {error, {transform_type_exception, {DT, {Class, Error}}}}
     end.
 

--- a/test/cuttlefish_integration_tests.erl
+++ b/test/cuttlefish_integration_tests.erl
@@ -174,6 +174,13 @@ duration_test() ->
     ErrConfig = cuttlefish_generator:map(Schema, Conf2),
     ?assertMatch({error, transform_datatypes, _}, ErrConfig).
 
+tagged_string_test() ->
+    Schema = cuttlefish_schema:files(["test/tagged_string.schema"]),
+
+    Conf = conf_parse:parse(<<"tagged_key = tagged:e614d97599dab483f\n">>),
+    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual({tagged, "e614d97599dab483f"}, proplists:get_value(tagged_key, proplists:get_value(cuttlefish, NewConfig))).
+
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),
     ActualKeys = lists:sort(proplists:get_keys(Actual)),

--- a/test/tagged_string.schema
+++ b/test/tagged_string.schema
@@ -1,0 +1,3 @@
+{mapping, "tagged_key", "cuttlefish.tagged_key", [
+  {datatype, [tagged_string]}
+]}.


### PR DESCRIPTION
In some cases the string data type is not
expressive enough. It requires key-specific
handling in the application, that is,
the key name becomes hardcoded if the string
has any special meaning to the app.

By introducing a new data type we enforce
a convention where a schema can define
a "special" kind (in fact, multiple kinds)
of string and it will be expressed in the
generated value, which will be a tagged tuple.

This approach avoids parser extensions,
whether this means native syntax or
a complex data type extension such as
the duration data type.

Closes #40.