### PR TITLE
Support for 'escaped values'

### DIFF
--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -56,9 +56,9 @@ line <- ((setting / include / comment / ws+) (crlf / eof)) / crlf %{
 
 %% A setting is a key and a value, joined by =, with surrounding
 %% whitespace ignored.
-setting <- ws* key ws* "=" ws* value ws* comment? %{
+setting <- ws* key ws* "=" ws* (escaped_value / unescaped_value) ws* comment? %{
     [ _, Key, _, _Eq, _, Value, _, _ ] = Node,
-    {Key, Value}
+    {Key, try_unicode_characters_to_list(Value, Idx)}
 %};
 
 %% A key is a series of dot-separated identifiers.
@@ -67,8 +67,14 @@ key <- head:word tail:("." word)* %{
     [try_unicode_characters_to_list(H, Idx)| [try_unicode_characters_to_list(W, Idx) || [_, W] <- T]]
 %};
 
+%% An escaped value is any character between single quotes except for EOF
+escaped_value <- "'" (!"'" .)* "'" %{
+    Stripped = string:trim(Node, both, [$']),
+    try_unicode_characters_to_list(Stripped, Idx)
+%};
+
 %% A value is any character, with trailing whitespace stripped.
-value <- (!((ws* crlf) / comment) .)+ %{
+unescaped_value <- (!((ws* crlf) / comment) .)+ %{
     try_unicode_characters_to_list(Node, Idx)
 %};
 
@@ -229,10 +235,19 @@ utf8_test() ->
     ?assertMatch(Expected, Actual),
     ok.
 
-invalid_utf8_test() ->
-    InvalidCodePoint = 16#11FFFF,
-    Expected = {error, <<"setting = thing">>, [InvalidCodePoint, $\n]},
-    Actual = conf_parse:parse("setting = thing" ++ [InvalidCodePoint] ++ "\n"),
+invalid_included_file_test() ->
+    Conf = conf_parse:file("test/invalid_include_file.conf"),
+    ?assertMatch({[], _PathWithNewLineAndCarriage, {{line,_}, {column, _}}}, Conf),
+    ok.
+
+invalid_included_dir_test() ->
+    Conf = conf_parse:file("test/invalid_include_dir.conf"),
+    ?assertMatch({[], _PathWithNewLineAndCarriage, {{line, _},{column, _}}}, Conf),
+    ok.
+
+escaped_string_test() ->
+    Expected = [{["setting"],"e9238-7_49%#sod7"}],
+    Actual = conf_parse:parse("setting = 'e9238-7_49%#sod7'" ++ "\n"),
     ?assertMatch(Expected, Actual),
     ok.
 

--- a/test/cuttlefish_integration_tests.erl
+++ b/test/cuttlefish_integration_tests.erl
@@ -181,6 +181,27 @@ tagged_string_test() ->
     NewConfig = cuttlefish_generator:map(Schema, Conf),
     ?assertEqual({tagged, "e614d97599dab483f"}, proplists:get_value(tagged_key, proplists:get_value(cuttlefish, NewConfig))).
 
+escaped_value_case1_test() ->
+    Schema = cuttlefish_schema:files(["test/escaped_values.schema"]),
+
+    Conf1 = conf_parse:parse("escaped.value = 'e9238-7_49%#sod7'\n"),
+    Config1 = cuttlefish_generator:map(Schema, Conf1),
+    %% with escaping, the '#' character and everything that follows it is preserved
+    ?assertEqual("e9238-7_49%#sod7", proplists:get_value(value, proplists:get_value(escaped, Config1))),
+
+    Conf2 = conf_parse:parse(<<"non_escaped.value = 557sd79238749%#sod7f9s87ee4\n">>),
+    Config2 = cuttlefish_generator:map(Schema, Conf2),
+    %% without escaping, everything after the '#' is cut off
+    ?assertEqual("557sd79238749%", proplists:get_value(value, proplists:get_value(non_escaped, Config2))).
+
+escaped_value_case2_test() ->
+    Schema = cuttlefish_schema:files(["test/escaped_values.schema"]),
+
+    %% characters that may appear in machine-generated passwords
+    Conf1 = conf_parse:parse("escaped.value = '!@$#%^&*+-_()|<>'\n"),
+    Config1 = cuttlefish_generator:map(Schema, Conf1),
+    ?assertEqual("!@$#%^&*+-_()|<>", proplists:get_value(value, proplists:get_value(escaped, Config1))).
+
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),
     ActualKeys = lists:sort(proplists:get_keys(Actual)),

--- a/test/escaped_values.schema
+++ b/test/escaped_values.schema
@@ -1,0 +1,7 @@
+{mapping, "escaped.value", "escaped.value", [
+  {datatype, [string]}
+]}.
+
+{mapping, "non_escaped.value", "non_escaped.value", [
+  {datatype, [string]}
+]}.


### PR DESCRIPTION
## Problem Definition

Currently Cuttlefish does not support string
values that include the # character.

This character is, however, used every so often
in generated passwords, identifiers, messaging protocol
(AMQP 0-9-1, MQTTv3.1, MQTTv5) routing patterns,
and other (often machine-produced) values.

## The Proposed Solution

This PR introduces an alternative value
representation:

``` ini
a.setting = 'sdkjf#hsdf$82836867#9237498'
```

which allows such values to be escaped using
single quotes.

Given the following schema file:

``` erl
{mapping, "escaped.value", "escaped.value", [
  {datatype, [string]}
]}.

{mapping, "non_escaped.value", "non_escaped.value", [
  {datatype, [string]}
]}.
```

and the following `.conf` file:

``` ini
escaped.value = '2f9sd79238-7_49%#sod7f9s87ee4'
non_escaped.value = 2f9sd79238749%#sod7f9s87ee4
```

Cuttlefish will now produce the following app config file:

``` erl
[
  %% this value was cut off at the comment character, '#'
  {non_escaped,[{value, "2f9sd79238749%"}]},
  %% '#' was preserved in this value which used single quote escaping
  {escaped,[{value,"2f9sd79238-7_49%#sod7f9s87ee4"}]}
].
```

## Limitations and Caveats

Single quotes are NOT
supported in these escaped values by design,
I do not thing that the `\'` escaping would
be worth our time. They are not particularly
common in Cuttlefish schemas according to Team RabbitMQ's
extensive experience with various configuration
files in the wild.

Closes #37.

References #31.