### PR TITLE
Require Erlang/OTP 24.x

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "21.3"}.
+{minimum_otp_vsn, "24.0"}.
 
 {project_plugins, [rebar3_hex]}.
 


### PR DESCRIPTION
We do not test Cuttlefish on Erlang/OTP 21. Its key users have long moved on from supporting Erlang/OTP 21 and even (in some cases, such as RabbitMQ) 24 or 25.

For comparison, Rebar3 has deprecated Erlang/OTP 23 support [back in May 2023](https://github.com/erlang/rebar3/releases/tag/3.21.0).