### PR TITLE
Support for key aliases

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,4 +27,4 @@
 
 {profiles, [{dev, [{deps, [neotoma]},
                    {plugins, [rebar3_neotoma_plugin]}]},
-            {test, [{deps, [bbmustache]}]}]}.
+            {test, [{deps, [bbmustache, proper]}]}]}.

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -561,4 +561,14 @@ assert_no_output(Setting) ->
 
     ?assertEqual([], generate_element(Mapping)).
 
+generate_does_not_emit_aliases_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {default, "val"},
+        {aliases, ["old.key"]}
+    ]}),
+    Generated = generate([Mapping]),
+    FlatLines = [lists:flatten(L) || L <- Generated],
+    ?assert(lists:any(fun(L) -> string:find(L, "new.key") =/= nomatch end, FlatLines)),
+    ?assertNot(lists:any(fun(L) -> string:find(L, "old.key") =/= nomatch end, FlatLines)).
+
 -endif.

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -31,7 +31,8 @@
 
 -spec build(cuttlefish_conf:conf(), cuttlefish_schema:schema(), [proplists:property()]) -> [string()].
 build(Conf, {_Translations, Mappings, _Validators} = _Schema, AdvConfig) ->
-    EffectiveConfig = lists:reverse(lists:sort(cuttlefish_generator:add_defaults(Conf, Mappings))),
+    AliasResolvedConf = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+    EffectiveConfig = lists:reverse(lists:sort(cuttlefish_generator:add_defaults(AliasResolvedConf, Mappings))),
     %% EffectiveConfig is a list of { [string()], term() }
 
     %% Returns the list of cuttlefish variables that have been overridden in advanced.config

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -208,6 +208,30 @@ probably_the_most_important_test() ->
     ?assertEqual("## [{app,[{setting3,\"z\"},{setting4,\"zz\"}]}]", lists:nth(16, Effective)),
     ok.
 
+alias_resolved_in_effective_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse(
+            {mapping, "new.key", "app.setting", [
+                {default, "default_val"},
+                {aliases, ["old.key"]}
+            ]}
+        )
+    ],
+    %% Only alias set: alias value appears under canonical key
+    Conf1 = [{["old", "key"], "alias_val"}],
+    Effective1 = build(Conf1, {[], Mappings, []}, []),
+    ?assert(lists:member("new.key = alias_val", Effective1)),
+    ?assertNot(lists:any(
+        fun(Line) -> string:find(Line, "old.key") =/= nomatch end,
+        Effective1)),
+    %% Both set: the canonical key wins, alias does not appear
+    Conf2 = [{["new", "key"], "canonical_val"}, {["old", "key"], "alias_val"}],
+    Effective2 = build(Conf2, {[], Mappings, []}, []),
+    ?assert(lists:member("new.key = canonical_val", Effective2)),
+    ?assertNot(lists:any(
+        fun(Line) -> string:find(Line, "old.key") =/= nomatch end,
+        Effective2)).
+
 process_advanced_test() ->
     Mappings = [
         cuttlefish_mapping:parse(

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -147,7 +147,19 @@ xlate({erl_parse_unexpected, Error}) ->
 xlate({parse_schema, Value}) ->
     io_lib:format("Unknown parse return: ~tp", [Value]);
 xlate({erl_scan, LineNo}) ->
-    ["Error scanning erlang near line ", integer_to_list(LineNo)].
+    ["Error scanning erlang near line ", integer_to_list(LineNo)];
+xlate({aliases_empty, Variable}) ->
+    io_lib:format("Empty aliases list for mapping ~ts", [Variable]);
+xlate({alias_is_self, Variable}) ->
+    io_lib:format("Alias for ~ts points to itself", [Variable]);
+xlate({fuzzy_alias_unsupported, Variable, Alias}) ->
+    io_lib:format("Fuzzy alias ~ts on mapping ~ts is not supported",
+                  [cuttlefish_variable:format(Alias), Variable]);
+xlate({alias_collision, {Alias, Variable1, Variable2}}) ->
+    io_lib:format("Alias ~ts is claimed by both ~ts and ~ts",
+                  [cuttlefish_variable:format(Alias),
+                   cuttlefish_variable:format(Variable1),
+                   cuttlefish_variable:format(Variable2)]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->
@@ -217,5 +229,13 @@ errorlist_maybe_test() ->
        ["hi", "what even is an error?", "bye"],
        errorlist_maybe(["hi", "what even is an error?", "bye"])),
     ok.
+
+%% Alias error xlate tests
+
+alias_error_xlate_test() ->
+    ?assertMatch("Empty" ++ _, lists:flatten(xlate({aliases_empty, "a.b"}))),
+    ?assertMatch("Alias" ++ _, lists:flatten(xlate({alias_is_self, "a.b"}))),
+    ?assertMatch("Fuzzy" ++ _, lists:flatten(xlate({fuzzy_alias_unsupported, "a.b", ["old", "$name", "key"]}))),
+    ?assertMatch("Alias" ++ _, lists:flatten(xlate({alias_collision, {["old", "key"], ["a", "b"], ["c", "d"]}}))).
 
 -endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -149,17 +149,28 @@ xlate({parse_schema, Value}) ->
 xlate({erl_scan, LineNo}) ->
     ["Error scanning erlang near line ", integer_to_list(LineNo)];
 xlate({aliases_empty, Variable}) ->
-    io_lib:format("Empty aliases list for mapping ~ts", [Variable]);
+    io_lib:format("No aliases declared for mapping ~ts (omit the aliases property instead)", [Variable]);
+xlate({aliases_is_bare_string, Variable}) ->
+    io_lib:format("Aliases value for mapping ~ts is a bare string; wrap it in a list, e.g. {aliases, [\"old.key\"]}", [Variable]);
+xlate({alias_not_a_string, Variable, Value}) ->
+    io_lib:format("Alias for mapping ~ts must be a string, got ~tp", [Variable, Value]);
+xlate({alias_and_aliases_both_set, Variable}) ->
+    io_lib:format("Mapping ~ts declares both {alias, ...} and {aliases, ...} (use one or the other)", [Variable]);
 xlate({alias_is_self, Variable}) ->
-    io_lib:format("Alias for ~ts points to itself", [Variable]);
+    io_lib:format("Mapping ~ts lists itself among its aliases", [Variable]);
+xlate({aliases_contain_duplicates, Variable}) ->
+    io_lib:format("Mapping ~ts has duplicate entries in its aliases list", [Variable]);
+xlate({aliases_invalid_value, Variable, Value}) ->
+    io_lib:format("Aliases for mapping ~ts must be a list of strings, got ~tp", [Variable, Value]);
 xlate({fuzzy_alias_unsupported, Variable, Alias}) ->
     io_lib:format("Fuzzy alias ~ts on mapping ~ts is not supported",
-                  [cuttlefish_variable:format(Alias), Variable]);
-xlate({alias_collision, {Alias, Variable1, Variable2}}) ->
+                  [Alias, Variable]);
+xlate({alias_shadows_canonical, {Alias, OwnerMapping}}) ->
+    io_lib:format("Alias ~ts on mapping ~ts shadows the canonical variable ~ts",
+                  [Alias, OwnerMapping, Alias]);
+xlate({alias_claimed_by_multiple_mappings, {Alias, Mapping1, Mapping2}}) ->
     io_lib:format("Alias ~ts is claimed by both ~ts and ~ts",
-                  [cuttlefish_variable:format(Alias),
-                   cuttlefish_variable:format(Variable1),
-                   cuttlefish_variable:format(Variable2)]).
+                  [Alias, Mapping1, Mapping2]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->
@@ -233,9 +244,27 @@ errorlist_maybe_test() ->
 %% Alias error xlate tests
 
 alias_error_xlate_test() ->
-    ?assertMatch("Empty" ++ _, lists:flatten(xlate({aliases_empty, "a.b"}))),
-    ?assertMatch("Alias" ++ _, lists:flatten(xlate({alias_is_self, "a.b"}))),
-    ?assertMatch("Fuzzy" ++ _, lists:flatten(xlate({fuzzy_alias_unsupported, "a.b", ["old", "$name", "key"]}))),
-    ?assertMatch("Alias" ++ _, lists:flatten(xlate({alias_collision, {["old", "key"], ["a", "b"], ["c", "d"]}}))).
+    ?assertEqual("No aliases declared for mapping a.b (omit the aliases property instead)",
+                 lists:flatten(xlate({aliases_empty, "a.b"}))),
+    ?assertEqual("Aliases value for mapping a.b is a bare string; "
+                 "wrap it in a list, e.g. {aliases, [\"old.key\"]}",
+                 lists:flatten(xlate({aliases_is_bare_string, "a.b"}))),
+    ?assertEqual("Mapping a.b lists itself among its aliases",
+                 lists:flatten(xlate({alias_is_self, "a.b"}))),
+    ?assertEqual("Fuzzy alias old.$name.key on mapping a.b is not supported",
+                 lists:flatten(xlate({fuzzy_alias_unsupported, "a.b", "old.$name.key"}))),
+    ?assertEqual("Alias for mapping a.b must be a string, got 42",
+                 lists:flatten(xlate({alias_not_a_string, "a.b", 42}))),
+    ?assertEqual("Mapping a.b has duplicate entries in its aliases list",
+                 lists:flatten(xlate({aliases_contain_duplicates, "a.b"}))),
+    ?assertEqual("Aliases for mapping a.b must be a list of strings, got 42",
+                 lists:flatten(xlate({aliases_invalid_value, "a.b", 42}))),
+    ?assertEqual("Mapping a.b declares both {alias, ...} and {aliases, ...} "
+                 "(use one or the other)",
+                 lists:flatten(xlate({alias_and_aliases_both_set, "a.b"}))),
+    ?assertEqual("Alias c.d on mapping a.b shadows the canonical variable c.d",
+                 lists:flatten(xlate({alias_shadows_canonical, {"c.d", "a.b"}}))),
+    ?assertEqual("Alias old.key is claimed by both a.b and c.d",
+                 lists:flatten(xlate({alias_claimed_by_multiple_mappings, {"old.key", "a.b", "c.d"}}))).
 
 -endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -129,6 +129,9 @@ xlate({circular_rhs, History}) ->
 xlate({substitution_missing_config, {Substitution, Variable}}) ->
     io_lib:format("'~ts' substitution requires a config variable '~ts' to be set",
                   [Substitution, Variable]);
+xlate({substitution_alias_key, {Substitution, Alias, Canonical}}) ->
+    io_lib:format("'~ts' substitution references '~ts', which is a deprecated alias for '~ts'",
+                  [Substitution, Alias, Canonical]);
 xlate({mapping_not_found, Variable}) ->
     [Variable, " not_found"];
 xlate({mapping_multiple, {Variable, {Hard, Fuzzy}}}) ->

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -95,11 +95,12 @@ map_add_defaults({_, Mappings, _} = Schema, Config, ParsedArgs) ->
                            {error, atom(), cuttlefish_error:errorlist()}.
 map_value_sub(Schema, Config, ParsedArgs) ->
     _ = ?LOG_DEBUG("Right Hand Side Substitutions"),
+    {_, Mappings, _} = Schema,
      case value_sub(Config) of
          {SubbedConfig, []} ->
             map_transform_datatypes(Schema, SubbedConfig, ParsedArgs);
          {_, EList} ->
-            {error, rhs_subs, {errorlist, EList}}
+            {error, rhs_subs, {errorlist, enrich_alias_sub_errors(EList, Mappings)}}
     end.
 
 -spec map_transform_datatypes(cuttlefish_schema:schema(), cuttlefish_conf:conf(), [proplists:property()]) ->
@@ -270,6 +271,28 @@ set_value([HeadToken|MoreTokens], PList, NewValue) ->
         Token,
         set_value(MoreTokens, OldValue, NewValue),
         PList).
+
+%% @doc Rewrites substitution_missing_config errors where the missing variable
+%% is a known alias key, to produce a more helpful error message.
+-spec enrich_alias_sub_errors([cuttlefish_error:error()], [cuttlefish_mapping:mapping()]) ->
+    [cuttlefish_error:error()].
+enrich_alias_sub_errors(EList, Mappings) ->
+    AliasIndex = lists:flatmap(fun(M) ->
+        Canonical = cuttlefish_mapping:variable(M),
+        [{Alias, Canonical} || Alias <- cuttlefish_mapping:aliases(M)]
+    end, Mappings),
+    [case E of
+        {error, {substitution_missing_config, {Src, Var}}} ->
+            VarTokenized = cuttlefish_variable:tokenize(Var),
+            case lists:keyfind(VarTokenized, 1, AliasIndex) of
+                {_, Canonical} ->
+                    {error, {substitution_alias_key,
+                             {Src, Var, cuttlefish_variable:format(Canonical)}}};
+                false ->
+                    E
+            end;
+        _ -> E
+    end || E <- EList].
 
 %% @doc Resolves alias keys to their canonical keys.
 %% Alias values are rewritten to the canonical key with a deprecation warning.
@@ -1531,5 +1554,21 @@ rhs_substitution_of_alias_key_fails_test() ->
     Conf = [{["old", "key"], "hello"}, {["other"], "$(old.key)/world"}],
     Result = map(Schema, Conf),
     ?assertMatch({error, rhs_subs, _}, Result).
+
+rhs_substitution_of_alias_key_error_message_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.a\", [\n"
+        "  {datatype, string},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+        "{mapping, \"other\", \"app.b\", [\n"
+        "  {datatype, string}\n"
+        "]}.\n"
+    ]),
+    Conf = [{["old", "key"], "hello"}, {["other"], "$(old.key)/world"}],
+    {error, rhs_subs, {errorlist, [{error, {substitution_alias_key, {_, MissingVar, Canonical}}}]}} =
+        map(Schema, Conf),
+    ?assertMatch({match, _}, re:run(cuttlefish_error:xlate({substitution_alias_key, {"other", MissingVar, Canonical}}),
+                                    "alias")).
 
 -endif.

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -78,7 +78,7 @@ restrict_mappings(M, {Mappings, Keys}, ConfigKeys) ->
 map_add_defaults({_, Mappings, _} = Schema, Config, ParsedArgs) ->
     %% Config at this point is just what's in the .conf file.
     %% First resolve any aliases to their canonical keys
-    _ = ?LOG_DEBUG("Resolving Aliases"),
+    _ = ?LOG_DEBUG("Resolving aliases"),
     AliasResolvedConfig = resolve_aliases(Config, Mappings),
     %% add_defaults/2 rolls the default values in from the schema
     _ = ?LOG_DEBUG("Adding Defaults"),

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -61,7 +61,11 @@ minimal_map({AllTranslations,AllMappings,V}, Config) ->
     map({RestrictedTranslations,RestrictedMappings,V}, Config, []).
 
 restrict_mappings(M, {Mappings, Keys}, ConfigKeys) ->
-    case sets:is_element(cuttlefish_mapping:variable(M), ConfigKeys) of
+    Variable = cuttlefish_mapping:variable(M),
+    Aliases = cuttlefish_mapping:aliases(M),
+    HasMatch = sets:is_element(Variable, ConfigKeys) orelse
+               lists:any(fun(A) -> sets:is_element(A, ConfigKeys) end, Aliases),
+    case HasMatch of
         true ->
             {[M|Mappings], sets:add_element(cuttlefish_mapping:mapping(M), Keys)};
         false ->
@@ -75,10 +79,10 @@ map_add_defaults({_, Mappings, _} = Schema, Config, ParsedArgs) ->
     %% Config at this point is just what's in the .conf file.
     %% First resolve any aliases to their canonical keys
     _ = ?LOG_DEBUG("Resolving Aliases"),
-    AConfig = resolve_aliases(Config, Mappings),
+    AliasResolvedConfig = resolve_aliases(Config, Mappings),
     %% add_defaults/2 rolls the default values in from the schema
     _ = ?LOG_DEBUG("Adding Defaults"),
-    DConfig = add_defaults(AConfig, Mappings),
+    DConfig = add_defaults(AliasResolvedConfig, Mappings),
     case cuttlefish_error:errorlist_maybe(DConfig) of
         {errorlist, EList} ->
             {error, add_defaults, {errorlist, EList}};
@@ -268,22 +272,22 @@ set_value([HeadToken|MoreTokens], PList, NewValue) ->
         PList).
 
 %% @doc Resolves alias keys to their canonical keys.
-%% For each mapping with aliases, if an alias key is present in Conf:
-%% - If canonical is also set: drop alias with warning
-%% - If canonical is not set: rewrite alias to canonical with warning
+%% Alias values are rewritten to the canonical key with a deprecation warning.
+%% Canonical takes precedence. If multiple aliases are set, the first one
+%% listed in the mapping's `aliases' property wins. Every set alias warns.
 -spec resolve_aliases(cuttlefish_conf:conf(), [cuttlefish_mapping:mapping()]) ->
     cuttlefish_conf:conf().
 resolve_aliases(Conf, Mappings) ->
     lists:foldl(fun(Mapping, ConfAcc) ->
         case cuttlefish_mapping:aliases(Mapping) of
             [] -> ConfAcc;
-            Aliases -> resolve_mapping_aliases(Mapping, Aliases, ConfAcc)
+            Aliases -> resolve_aliases_for_single_mapping(Mapping, Aliases, ConfAcc)
         end
     end, Conf, Mappings).
 
-resolve_mapping_aliases(Mapping, Aliases, Conf) ->
+resolve_aliases_for_single_mapping(Mapping, Aliases, Conf) ->
     Canonical = cuttlefish_mapping:variable(Mapping),
-    CanonicalFmt = cuttlefish_variable:format(Canonical),
+    CanonicalStr = cuttlefish_variable:format(Canonical),
     lists:foldl(fun(AliasVar, ConfAcc) ->
         %% Recheck on every iteration: a previous alias in this
         %% fold may have inserted the canonical key.
@@ -292,14 +296,14 @@ resolve_mapping_aliases(Mapping, Aliases, Conf) ->
             false ->
                 ConfAcc;
             {_, _} when CanonicalSet ->
-                AliasFmt = cuttlefish_variable:format(AliasVar),
+                AliasStr = cuttlefish_variable:format(AliasVar),
                 _ = ?LOG_WARNING("~ts is deprecated and ignored "
-                             "in favor of ~ts", [AliasFmt, CanonicalFmt]),
+                             "in favor of ~ts", [AliasStr, CanonicalStr]),
                 lists:keydelete(AliasVar, 1, ConfAcc);
             {_, Value} ->
-                AliasFmt = cuttlefish_variable:format(AliasVar),
+                AliasStr = cuttlefish_variable:format(AliasVar),
                 _ = ?LOG_WARNING("~ts is deprecated, use ~ts instead",
-                             [AliasFmt, CanonicalFmt]),
+                             [AliasStr, CanonicalStr]),
                 [{Canonical, Value} | lists:keydelete(AliasVar, 1, ConfAcc)]
         end
     end, Conf, Aliases).
@@ -1346,6 +1350,10 @@ resolve_alias_multiple_first_wins_test() ->
     Resolved = resolve_aliases(Conf, [Mapping]),
     ?assertEqual([{["new", "key"], "1"}], Resolved).
 
+resolve_alias_empty_mappings_test() ->
+    Conf = [{["a", "b"], "val"}],
+    ?assertEqual(Conf, resolve_aliases(Conf, [])).
+
 resolve_alias_no_aliases_passthrough_test() ->
     Mapping = cuttlefish_mapping:parse({mapping, "a.b", "app.x", [
         {datatype, string}
@@ -1385,7 +1393,8 @@ resolve_alias_warns_on_deprecated_key_test() ->
     ]}),
     _ = resolve_aliases([{["old", "key"], "42"}], [Mapping]),
     [Log] = cuttlefish_test_logging:get_logs(),
-    ?assertMatch({match, _}, re:run(Log, "old\\.key.*deprecated.*new\\.key")).
+    ?assertMatch({match, _},
+        re:run(Log, "old\\.key is deprecated, use new\\.key instead")).
 
 resolve_alias_warns_on_ignored_key_test() ->
     _ = cuttlefish_test_logging:set_up(),
@@ -1395,7 +1404,8 @@ resolve_alias_warns_on_ignored_key_test() ->
     ]}),
     _ = resolve_aliases([{["new", "key"], "1"}, {["old", "key"], "2"}], [Mapping]),
     [Log] = cuttlefish_test_logging:get_logs(),
-    ?assertMatch({match, _}, re:run(Log, "old\\.key.*deprecated.*ignored")).
+    ?assertMatch({match, _},
+        re:run(Log, "old\\.key is deprecated and ignored in favor of new\\.key")).
 
 resolve_alias_multiple_all_warn_test() ->
     _ = cuttlefish_test_logging:set_up(),
@@ -1465,5 +1475,61 @@ alias_validation_runs_test() ->
     Conf = [{["old", "key"], "-5"}],
     Result = map(Schema, Conf),
     ?assertMatch({error, validation, _}, Result).
+
+minimal_map_resolves_alias_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.setting\", [\n"
+        "  {datatype, integer},\n"
+        "  {default, 10},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+    ]),
+    Conf = [{["old", "key"], "42"}],
+    Result = minimal_map(Schema, Conf),
+    ?assertEqual(42, proplists:get_value(setting, proplists:get_value(app, Result))).
+
+minimal_map_excludes_mapping_without_alias_or_canonical_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.setting\", [\n"
+        "  {datatype, integer},\n"
+        "  {default, 10},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+    ]),
+    %% Neither canonical nor alias in config — mapping should be excluded
+    Result = minimal_map(Schema, []),
+    ?assertEqual([], Result).
+
+%% RHS substitutions reference the canonical key, not the alias.
+%% $(old.key) won't resolve after alias rewriting — use $(new.key).
+rhs_substitution_uses_canonical_not_alias_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.a\", [\n"
+        "  {datatype, string},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+        "{mapping, \"other\", \"app.b\", [\n"
+        "  {datatype, string}\n"
+        "]}.\n"
+    ]),
+    %% $(new.key) works after alias resolution
+    Conf = [{["old", "key"], "hello"}, {["other"], "$(new.key)/world"}],
+    Result = map(Schema, Conf),
+    ?assertEqual("hello/world", proplists:get_value(b, proplists:get_value(app, Result))).
+
+rhs_substitution_of_alias_key_fails_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.a\", [\n"
+        "  {datatype, string},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+        "{mapping, \"other\", \"app.b\", [\n"
+        "  {datatype, string}\n"
+        "]}.\n"
+    ]),
+    %% $(old.key) fails because the alias has been rewritten
+    Conf = [{["old", "key"], "hello"}, {["other"], "$(old.key)/world"}],
+    Result = map(Schema, Conf),
+    ?assertMatch({error, rhs_subs, _}, Result).
 
 -endif.

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -32,7 +32,7 @@
 -define(LSUBLEN, 2).
 -define(RSUBLEN, 1).
 
--export([map/2, map/3, find_mapping/2, add_defaults/2, minimal_map/2]).
+-export([map/2, map/3, find_mapping/2, add_defaults/2, minimal_map/2, resolve_aliases/2]).
 
 -spec map(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
                  [proplists:property()] |
@@ -73,9 +73,12 @@ restrict_mappings(M, {Mappings, Keys}, ConfigKeys) ->
                               {error, atom(), cuttlefish_error:errorlist()}.
 map_add_defaults({_, Mappings, _} = Schema, Config, ParsedArgs) ->
     %% Config at this point is just what's in the .conf file.
+    %% First resolve any aliases to their canonical keys
+    _ = ?LOG_DEBUG("Resolving Aliases"),
+    AConfig = resolve_aliases(Config, Mappings),
     %% add_defaults/2 rolls the default values in from the schema
     _ = ?LOG_DEBUG("Adding Defaults"),
-    DConfig = add_defaults(Config, Mappings),
+    DConfig = add_defaults(AConfig, Mappings),
     case cuttlefish_error:errorlist_maybe(DConfig) of
         {errorlist, EList} ->
             {error, add_defaults, {errorlist, EList}};
@@ -263,6 +266,43 @@ set_value([HeadToken|MoreTokens], PList, NewValue) ->
         Token,
         set_value(MoreTokens, OldValue, NewValue),
         PList).
+
+%% @doc Resolves alias keys to their canonical keys.
+%% For each mapping with aliases, if an alias key is present in Conf:
+%% - If canonical is also set: drop alias with warning
+%% - If canonical is not set: rewrite alias to canonical with warning
+-spec resolve_aliases(cuttlefish_conf:conf(), [cuttlefish_mapping:mapping()]) ->
+    cuttlefish_conf:conf().
+resolve_aliases(Conf, Mappings) ->
+    lists:foldl(fun(Mapping, ConfAcc) ->
+        case cuttlefish_mapping:aliases(Mapping) of
+            [] -> ConfAcc;
+            Aliases -> resolve_mapping_aliases(Mapping, Aliases, ConfAcc)
+        end
+    end, Conf, Mappings).
+
+resolve_mapping_aliases(Mapping, Aliases, Conf) ->
+    Canonical = cuttlefish_mapping:variable(Mapping),
+    CanonicalFmt = cuttlefish_variable:format(Canonical),
+    lists:foldl(fun(AliasVar, ConfAcc) ->
+        %% Recheck on every iteration: a previous alias in this
+        %% fold may have inserted the canonical key.
+        CanonicalSet = lists:keymember(Canonical, 1, ConfAcc),
+        case lists:keyfind(AliasVar, 1, ConfAcc) of
+            false ->
+                ConfAcc;
+            {_, _} when CanonicalSet ->
+                AliasFmt = cuttlefish_variable:format(AliasVar),
+                _ = ?LOG_WARNING("~ts is deprecated and ignored "
+                             "in favor of ~ts", [AliasFmt, CanonicalFmt]),
+                lists:keydelete(AliasVar, 1, ConfAcc);
+            {_, Value} ->
+                AliasFmt = cuttlefish_variable:format(AliasVar),
+                _ = ?LOG_WARNING("~ts is deprecated, use ~ts instead",
+                             [AliasFmt, CanonicalFmt]),
+                [{Canonical, Value} | lists:keydelete(AliasVar, 1, ConfAcc)]
+        end
+    end, Conf, Aliases).
 
 %% @doc adds default values from the schema when something's not
 %% defined in the Conf, to give a complete app.config
@@ -1271,5 +1311,159 @@ value_sub_paren_test() ->
     ?assertEqual([], Errors),
     ?assertEqual("C)/C)", proplists:get_value(["a"], NewConf)),
     ok.
+
+%% Alias resolution tests
+
+resolve_alias_only_alias_set_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key"]}
+    ]}),
+    Conf = [{["old", "key"], "42"}],
+    Resolved = resolve_aliases(Conf, [Mapping]),
+    ?assertEqual([{["new", "key"], "42"}], Resolved).
+
+resolve_alias_canonical_wins_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key"]}
+    ]}),
+    Conf = [{["new", "key"], "100"}, {["old", "key"], "42"}],
+    Resolved = resolve_aliases(Conf, [Mapping]),
+    ?assertEqual([{["new", "key"], "100"}], Resolved).
+
+resolve_alias_neither_set_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {default, 7}, {aliases, ["old.key"]}
+    ]}),
+    ?assertEqual([], resolve_aliases([], [Mapping])).
+
+resolve_alias_multiple_first_wins_test() ->
+    %% Two aliases set, canonical not set. First alias wins,
+    %% second sees canonical now exists and is dropped.
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key", "oldest.key"]}
+    ]}),
+    Conf = [{["old", "key"], "1"}, {["oldest", "key"], "2"}],
+    Resolved = resolve_aliases(Conf, [Mapping]),
+    ?assertEqual([{["new", "key"], "1"}], Resolved).
+
+resolve_alias_no_aliases_passthrough_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "a.b", "app.x", [
+        {datatype, string}
+    ]}),
+    Conf = [{["a", "b"], "val"}, {["c", "d"], "other"}],
+    ?assertEqual(Conf, resolve_aliases(Conf, [Mapping])).
+
+resolve_alias_preserves_unrelated_keys_test() ->
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key"]}
+    ]}),
+    Conf = [{["old", "key"], "42"}, {["unrelated", "key"], "hello"}],
+    Resolved = resolve_aliases(Conf, [Mapping]),
+    ?assertEqual("hello", proplists:get_value(["unrelated", "key"], Resolved)),
+    ?assertEqual("42", proplists:get_value(["new", "key"], Resolved)),
+    ?assertEqual(2, length(Resolved)).
+
+resolve_alias_multiple_independent_mappings_test() ->
+    %% Two mappings, each with their own alias. No interaction.
+    M1 = cuttlefish_mapping:parse({mapping, "new.a", "app.x", [
+        {datatype, integer}, {aliases, ["old.a"]}
+    ]}),
+    M2 = cuttlefish_mapping:parse({mapping, "new.b", "app.y", [
+        {datatype, string}, {aliases, ["old.b"]}
+    ]}),
+    Conf = [{["old", "a"], "1"}, {["old", "b"], "hello"}],
+    Resolved = resolve_aliases(Conf, [M1, M2]),
+    ?assertEqual("1", proplists:get_value(["new", "a"], Resolved)),
+    ?assertEqual("hello", proplists:get_value(["new", "b"], Resolved)),
+    ?assertEqual(2, length(Resolved)).
+
+resolve_alias_warns_on_deprecated_key_test() ->
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key"]}
+    ]}),
+    _ = resolve_aliases([{["old", "key"], "42"}], [Mapping]),
+    [Log] = cuttlefish_test_logging:get_logs(),
+    ?assertMatch({match, _}, re:run(Log, "old\\.key.*deprecated.*new\\.key")).
+
+resolve_alias_warns_on_ignored_key_test() ->
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key"]}
+    ]}),
+    _ = resolve_aliases([{["new", "key"], "1"}, {["old", "key"], "2"}], [Mapping]),
+    [Log] = cuttlefish_test_logging:get_logs(),
+    ?assertMatch({match, _}, re:run(Log, "old\\.key.*deprecated.*ignored")).
+
+resolve_alias_multiple_all_warn_test() ->
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Mapping = cuttlefish_mapping:parse({mapping, "new.key", "app.setting", [
+        {datatype, integer}, {aliases, ["old.key", "oldest.key"]}
+    ]}),
+    _ = resolve_aliases([{["old", "key"], "1"}, {["oldest", "key"], "2"}], [Mapping]),
+    Logs = cuttlefish_test_logging:get_logs(),
+    ?assertEqual(2, length(Logs)).
+
+%% End-to-end tests through map/2
+
+alias_end_to_end_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.setting\", [\n"
+        "  {datatype, integer},\n"
+        "  {default, 10},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+    ]),
+    Conf = [{["old", "key"], "42"}],
+    Result = map(Schema, Conf),
+    ?assertEqual(42, proplists:get_value(setting, proplists:get_value(app, Result))).
+
+alias_with_translation_test() ->
+    %% Translation sees the canonical key, never the alias.
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.a\", \"app.combined\", [\n"
+        "  {datatype, integer},\n"
+        "  {aliases, [\"old.a\"]}\n"
+        "]}.\n"
+        "{mapping, \"new.b\", \"app.combined\", [\n"
+        "  {datatype, integer}\n"
+        "]}.\n"
+        "{translation, \"app.combined\", fun(Conf) ->\n"
+        "    A = cuttlefish:conf_get(\"new.a\", Conf),\n"
+        "    B = cuttlefish:conf_get(\"new.b\", Conf),\n"
+        "    {A, B}\n"
+        "end}.\n"
+    ]),
+    Conf = [{["old", "a"], "1"}, {["new", "b"], "2"}],
+    Result = map(Schema, Conf),
+    ?assertEqual({1, 2}, proplists:get_value(combined, proplists:get_value(app, Result))).
+
+alias_default_applies_when_neither_set_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.setting\", [\n"
+        "  {datatype, integer},\n"
+        "  {default, 99},\n"
+        "  {aliases, [\"old.key\"]}\n"
+        "]}.\n"
+    ]),
+    Result = map(Schema, []),
+    ?assertEqual(99, proplists:get_value(setting, proplists:get_value(app, Result))).
+
+alias_validation_runs_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"new.key\", \"app.setting\", [\n"
+        "  {datatype, integer},\n"
+        "  {aliases, [\"old.key\"]},\n"
+        "  {validators, [\"positive\"]}\n"
+        "]}.\n"
+        "{validator, \"positive\", \"must be positive\",\n"
+        "  fun(X) -> X > 0 end}.\n"
+    ]),
+    Conf = [{["old", "key"], "-5"}],
+    Result = map(Schema, Conf),
+    ?assertMatch({error, validation, _}, Result).
 
 -endif.

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -122,36 +122,56 @@ parse(X) ->
 -spec parse_aliases(string(), cuttlefish_variable:variable(), [proplists:property()], boolean()) ->
     [cuttlefish_variable:variable()] | cuttlefish_error:error().
 parse_aliases(Variable, VarTokenized, Proplist, IsMerge) ->
-    case proplists:get_value(aliases, Proplist) of
-        undefined ->
-            [];
-        [] when IsMerge ->
-            [];
-        [] ->
-            {error, {aliases_empty, Variable}};
-        RawAliases when is_list(RawAliases) ->
-            TokenizedAliases = [cuttlefish_variable:tokenize(A) || A <- RawAliases],
-            case lists:member(VarTokenized, TokenizedAliases) of
+    RawAliases = case {proplists:get_value(alias, Proplist),
+                       proplists:get_value(aliases, Proplist)} of
+        {undefined, undefined} -> undefined;
+        {Single, undefined} when is_list(Single) -> [Single];
+        {Single, undefined} -> {error, {alias_not_a_string, Variable, Single}};
+        {undefined, Multi} -> Multi;
+        {_, _} -> {error, {alias_and_aliases_both_set, Variable}}
+    end,
+    validate_raw_aliases(Variable, VarTokenized, RawAliases, IsMerge).
+
+validate_raw_aliases(_Variable, _VarTokenized, undefined, _IsMerge) ->
+    [];
+validate_raw_aliases(_Variable, _VarTokenized, [] = _RawAliases, true = _IsMerge) ->
+    [];
+validate_raw_aliases(Variable, _VarTokenized, [], _IsMerge) ->
+    {error, {aliases_empty, Variable}};
+validate_raw_aliases(_Variable, _VarTokenized, {error, _} = Error, _IsMerge) ->
+    Error;
+validate_raw_aliases(Variable, _VarTokenized, [H|_], _IsMerge) when is_integer(H) ->
+    %% Bare string: {aliases, "old.key"} instead of {aliases, ["old.key"]}
+    {error, {aliases_is_bare_string, Variable}};
+validate_raw_aliases(Variable, VarTokenized, RawAliases, _IsMerge) when is_list(RawAliases) ->
+    TokenizedAliases = [cuttlefish_variable:tokenize(A) || A <- RawAliases],
+    case lists:member(VarTokenized, TokenizedAliases) of
+        true ->
+            {error, {alias_is_self, Variable}};
+        false ->
+            case length(lists:usort(TokenizedAliases)) < length(TokenizedAliases) of
                 true ->
-                    {error, {alias_is_self, Variable}};
+                    {error, {aliases_contain_duplicates, Variable}};
                 false ->
-                    case find_fuzzy_alias(TokenizedAliases) of
+                    case first_fuzzy_alias(TokenizedAliases) of
                         {fuzzy, FuzzyAlias} ->
-                            {error, {fuzzy_alias_unsupported, Variable, FuzzyAlias}};
+                            {error, {fuzzy_alias_unsupported, Variable, cuttlefish_variable:format(FuzzyAlias)}};
                         ok ->
                             TokenizedAliases
                     end
             end
-    end.
+    end;
+validate_raw_aliases(Variable, _VarTokenized, BadValue, _IsMerge) ->
+    {error, {aliases_invalid_value, Variable, BadValue}}.
 
--spec find_fuzzy_alias([cuttlefish_variable:variable()]) -> ok | {fuzzy, cuttlefish_variable:variable()}.
-find_fuzzy_alias([]) ->
+-spec first_fuzzy_alias([cuttlefish_variable:variable()]) -> ok | {fuzzy, cuttlefish_variable:variable()}.
+first_fuzzy_alias([]) ->
     ok;
-find_fuzzy_alias([Alias|Rest]) ->
+first_fuzzy_alias([Alias|Rest]) ->
     IsFuzzy = lists:any(fun([$$|_]) -> true; (_) -> false end, Alias),
     case IsFuzzy of
         true -> {fuzzy, Alias};
-        false -> find_fuzzy_alias(Rest)
+        false -> first_fuzzy_alias(Rest)
     end.
 
 %% If this mapping exists, do something.
@@ -190,7 +210,7 @@ merge(NewMappingSource, OldMapping) ->
         level = choose(level, NewMappingSource, MergeMapping, OldMapping),
         doc = choose(doc, NewMappingSource, MergeMapping, OldMapping),
         include_default = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
-        new_conf_value = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
+        new_conf_value = choose(new_conf_value, NewMappingSource, MergeMapping, OldMapping),
         validators = choose(validators, NewMappingSource, MergeMapping, OldMapping),
         see = choose(see, NewMappingSource, MergeMapping, OldMapping),
         hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping),
@@ -198,12 +218,14 @@ merge(NewMappingSource, OldMapping) ->
     }.
 
 choose(Field, {_, _, _, PreParseMergeProps}, MergeMapping, OldMapping) ->
-    Which = case {Field,
-                  proplists:is_defined(Field, PreParseMergeProps),
-                  proplists:get_value(Field, PreParseMergeProps)} of
+    IsDefined = proplists:is_defined(Field, PreParseMergeProps) orelse
+                (Field =:= aliases andalso proplists:is_defined(alias, PreParseMergeProps)),
+    Value = proplists:get_value(Field, PreParseMergeProps),
+    %% Empty see/doc in a merge mapping is treated as "not specified" (inherit),
+    %% but empty aliases is an intentional "clear all aliases" directive.
+    Which = case {Field, IsDefined, Value} of
                 {see, _, []} -> old;
                 {doc, _, []} -> old;
-                {aliases, _, []} -> old;
                 {_, true, _} -> new;
                 _ -> old
     end,
@@ -616,6 +638,48 @@ aliases_self_among_multiple_error_test() ->
     ]}),
     ?assertMatch({error, {alias_is_self, _}}, Result).
 
+alias_singular_test() ->
+    M = parse({mapping, "new.key", "app.setting", [
+        {alias, "old.key"}
+    ]}),
+    ?assertEqual([["old", "key"]], aliases(M)).
+
+alias_singular_self_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{alias, "a.b"}]}),
+    ?assertMatch({error, {alias_is_self, _}}, Result).
+
+alias_and_aliases_both_set_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [
+        {alias, "old.key"}, {aliases, ["older.key"]}
+    ]}),
+    ?assertMatch({error, {alias_and_aliases_both_set, _}}, Result).
+
+aliases_bare_string_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, "old.key"}]}),
+    ?assertMatch({error, {aliases_is_bare_string, _}}, Result).
+
+alias_singular_not_a_string_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{alias, 42}]}),
+    ?assertMatch({error, {alias_not_a_string, "a.b", 42}}, Result).
+
+aliases_duplicate_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [
+        {aliases, ["old.key", "old.key"]}
+    ]}),
+    ?assertMatch({error, {aliases_contain_duplicates, _}}, Result).
+
+aliases_invalid_value_atom_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, deprecated}]}),
+    ?assertMatch({error, {aliases_invalid_value, "a.b", deprecated}}, Result).
+
+aliases_invalid_value_integer_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, 42}]}),
+    ?assertMatch({error, {aliases_invalid_value, "a.b", 42}}, Result).
+
+aliases_invalid_value_tuple_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, {"a", "b"}}]}),
+    ?assertMatch({error, {aliases_invalid_value, "a.b", {"a", "b"}}}, Result).
+
 aliases_fuzzy_error_test() ->
     Result = parse({mapping, "a.b", "app.setting", [
         {aliases, ["old.$name.key"]}
@@ -640,13 +704,24 @@ aliases_merge_inherits_test() ->
     ?assertEqual([["old", "ab"]], aliases(Merged)),
     ?assertEqual(2, default(Merged)).
 
-aliases_merge_empty_inherits_test() ->
-    %% Empty aliases list in merge mapping should inherit from old
+aliases_merge_singular_replaces_test() ->
     OldM = parse({mapping, "a.b", "app.x", [
-        {default, 1}, {aliases, ["old.ab"]}
+        {default, 1}, {datatype, integer}, {aliases, ["old.ab"]}
+    ]}),
+    NewRaw = {mapping, "a.b", "app.x", [merge, {alias, "newer.ab"}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual([["newer", "ab"]], aliases(Merged)),
+    ?assertEqual(1, default(Merged)).
+
+aliases_merge_empty_clears_test() ->
+    %% Explicit {aliases, []} in merge mapping clears inherited aliases
+    OldM = parse({mapping, "a.b", "app.x", [
+        {default, 1}, {datatype, integer}, {aliases, ["old.ab"]}
     ]}),
     NewRaw = {mapping, "a.b", "app.x", [merge, {aliases, []}]},
     [Merged] = parse_and_merge(NewRaw, [OldM]),
-    ?assertEqual([["old", "ab"]], aliases(Merged)).
+    ?assertEqual([], aliases(Merged)),
+    ?assertEqual(1, default(Merged)),
+    ?assertEqual([integer], datatype(Merged)).
 
 -endif.

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -38,7 +38,8 @@
         validators = [] :: [string()],
         is_merge = false :: boolean(),
         see = [] :: [cuttlefish_variable:variable()],
-        hidden = false :: boolean()
+        hidden = false :: boolean(),
+        aliases = [] :: [cuttlefish_variable:variable()]
     }).
 
 -type mapping() :: #mapping{}.
@@ -65,7 +66,8 @@
     replace/2,
     validators/1,
     validators/2,
-    remove_all_but_first/2
+    remove_all_but_first/2,
+    aliases/1
     ]).
 
 -spec parse(raw_mapping()) -> mapping() | cuttlefish_error:error().
@@ -88,12 +90,18 @@ parse({mapping, Variable, Mapping, Proplist}) ->
         D -> [D]
     end,
 
-    case Datatype of
-        {error, _} ->
+    VarTokenized = cuttlefish_variable:tokenize(Variable),
+    IsMerge = proplists:is_defined(merge, Proplist),
+    AliasesResult = parse_aliases(Variable, VarTokenized, Proplist, IsMerge),
+
+    case {Datatype, AliasesResult} of
+        {{error, _}, _} ->
             Datatype;
-        _ ->
+        {_, {error, _} = AliasError} ->
+            AliasError;
+        {_, TokenizedAliases} ->
             #mapping{
-                variable = cuttlefish_variable:tokenize(Variable),
+                variable = VarTokenized,
                 default = proplists:get_value(default, Proplist),
                 commented = proplists:get_value(commented, Proplist),
                 mapping = Mapping,
@@ -104,11 +112,47 @@ parse({mapping, Variable, Mapping, Proplist}) ->
                 include_default = proplists:get_value(include_default, Proplist),
                 new_conf_value = proplists:get_value(new_conf_value, Proplist),
                 validators = proplists:get_value(validators, Proplist, []),
-                hidden = proplists:get_value(hidden, Proplist, false)
+                hidden = proplists:get_value(hidden, Proplist, false),
+                aliases = TokenizedAliases
             }
     end;
 parse(X) ->
     {error, {mapping_parse, X}}.
+
+-spec parse_aliases(string(), cuttlefish_variable:variable(), [proplists:property()], boolean()) ->
+    [cuttlefish_variable:variable()] | cuttlefish_error:error().
+parse_aliases(Variable, VarTokenized, Proplist, IsMerge) ->
+    case proplists:get_value(aliases, Proplist) of
+        undefined ->
+            [];
+        [] when IsMerge ->
+            [];
+        [] ->
+            {error, {aliases_empty, Variable}};
+        RawAliases when is_list(RawAliases) ->
+            TokenizedAliases = [cuttlefish_variable:tokenize(A) || A <- RawAliases],
+            case lists:member(VarTokenized, TokenizedAliases) of
+                true ->
+                    {error, {alias_is_self, Variable}};
+                false ->
+                    case find_fuzzy_alias(TokenizedAliases) of
+                        {fuzzy, FuzzyAlias} ->
+                            {error, {fuzzy_alias_unsupported, Variable, FuzzyAlias}};
+                        ok ->
+                            TokenizedAliases
+                    end
+            end
+    end.
+
+-spec find_fuzzy_alias([cuttlefish_variable:variable()]) -> ok | {fuzzy, cuttlefish_variable:variable()}.
+find_fuzzy_alias([]) ->
+    ok;
+find_fuzzy_alias([Alias|Rest]) ->
+    IsFuzzy = lists:any(fun([$$|_]) -> true; (_) -> false end, Alias),
+    case IsFuzzy of
+        true -> {fuzzy, Alias};
+        false -> find_fuzzy_alias(Rest)
+    end.
 
 %% If this mapping exists, do something.
 %% That something is usually a simple replace, unless the proplist in
@@ -149,7 +193,8 @@ merge(NewMappingSource, OldMapping) ->
         new_conf_value = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
         validators = choose(validators, NewMappingSource, MergeMapping, OldMapping),
         see = choose(see, NewMappingSource, MergeMapping, OldMapping),
-        hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping)
+        hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping),
+        aliases = choose(aliases, NewMappingSource, MergeMapping, OldMapping)
     }.
 
 choose(Field, {_, _, _, PreParseMergeProps}, MergeMapping, OldMapping) ->
@@ -158,6 +203,7 @@ choose(Field, {_, _, _, PreParseMergeProps}, MergeMapping, OldMapping) ->
                   proplists:get_value(Field, PreParseMergeProps)} of
                 {see, _, []} -> old;
                 {doc, _, []} -> old;
+                {aliases, _, []} -> old;
                 {_, true, _} -> new;
                 _ -> old
     end,
@@ -215,6 +261,9 @@ new_conf_value(M) -> M#mapping.new_conf_value.
 
 -spec validators(mapping()) -> [string()].
 validators(M) -> M#mapping.validators.
+
+-spec aliases(mapping()) -> [cuttlefish_variable:variable()].
+aliases(M) -> M#mapping.aliases.
 
 -spec validators(mapping(), [cuttlefish_validator:validator()]) -> [cuttlefish_validator:validator()].
 validators(M, Validators) ->
@@ -540,5 +589,64 @@ datatype_cannot_be_empty_list_test() ->
     }),
     ?assertMatch({error, _}, Mapping),
     ok.
+
+%% Aliases tests
+
+aliases_parse_test() ->
+    M = parse({mapping, "new.key", "app.setting", [
+        {aliases, ["old.key", "older.key"]}
+    ]}),
+    ?assertEqual([["old", "key"], ["older", "key"]], aliases(M)).
+
+aliases_omitted_test() ->
+    M = parse({mapping, "new.key", "app.setting", []}),
+    ?assertEqual([], aliases(M)).
+
+aliases_empty_list_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, []}]}),
+    ?assertMatch({error, {aliases_empty, _}}, Result).
+
+aliases_self_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [{aliases, ["a.b"]}]}),
+    ?assertMatch({error, {alias_is_self, _}}, Result).
+
+aliases_self_among_multiple_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [
+        {aliases, ["old.key", "a.b"]}
+    ]}),
+    ?assertMatch({error, {alias_is_self, _}}, Result).
+
+aliases_fuzzy_error_test() ->
+    Result = parse({mapping, "a.b", "app.setting", [
+        {aliases, ["old.$name.key"]}
+    ]}),
+    ?assertMatch({error, {fuzzy_alias_unsupported, _, _}}, Result).
+
+aliases_merge_replaces_test() ->
+    OldM = parse({mapping, "a.b", "app.x", [
+        {default, 1}, {datatype, integer}, {aliases, ["old.ab"]}
+    ]}),
+    NewRaw = {mapping, "a.b", "app.x", [merge, {aliases, ["older.ab"]}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual([["older", "ab"]], aliases(Merged)),
+    ?assertEqual(1, default(Merged)).
+
+aliases_merge_inherits_test() ->
+    OldM = parse({mapping, "a.b", "app.x", [
+        {default, 1}, {datatype, integer}, {aliases, ["old.ab"]}
+    ]}),
+    NewRaw = {mapping, "a.b", "app.x", [merge, {default, 2}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual([["old", "ab"]], aliases(Merged)),
+    ?assertEqual(2, default(Merged)).
+
+aliases_merge_empty_inherits_test() ->
+    %% Empty aliases list in merge mapping should inherit from old
+    OldM = parse({mapping, "a.b", "app.x", [
+        {default, 1}, {aliases, ["old.ab"]}
+    ]}),
+    NewRaw = {mapping, "a.b", "app.x", [merge, {aliases, []}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual([["old", "ab"]], aliases(Merged)).
 
 -endif.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -111,46 +111,44 @@ filter({Translations, Mappings, Validators}) ->
     case validate_aliases(NewMappings) of
         ok ->
             {Translations, NewMappings, Validators};
-        {error, _} = Error ->
-            {errorlist, [Error]}
+        {errorlist, _} = Errors ->
+            Errors
     end.
 
 %% @doc Validates that aliases don't collide with other mappings' canonical
 %% variables or with aliases from other mappings.
--spec validate_aliases([cuttlefish_mapping:mapping()]) -> ok | cuttlefish_error:error().
+-spec validate_aliases([cuttlefish_mapping:mapping()]) ->
+    ok | cuttlefish_error:errorlist().
 validate_aliases(Mappings) ->
-    %% Build an index of all canonical variables
-    CanonicalVars = [{cuttlefish_mapping:variable(M), M} || M <- Mappings],
-    %% Build an index of all aliases -> owning mapping
-    AliasIndex = lists:foldl(fun(M, Acc) ->
+    CanonicalVarSet = sets:from_list(
+        [cuttlefish_mapping:variable(M) || M <- Mappings]),
+    AliasIndex = lists:flatmap(fun(M) ->
         Variable = cuttlefish_mapping:variable(M),
-        Aliases = cuttlefish_mapping:aliases(M),
-        lists:foldl(fun(Alias, InnerAcc) ->
-            [{Alias, Variable} | InnerAcc]
-        end, Acc, Aliases)
-    end, [], Mappings),
+        [{Alias, Variable} || Alias <- cuttlefish_mapping:aliases(M)]
+    end, Mappings),
+    collect_alias_collision_errors(AliasIndex, CanonicalVarSet, []).
 
-    %% Check for collisions
-    validate_alias_collisions(AliasIndex, CanonicalVars, AliasIndex).
-
-validate_alias_collisions([], _CanonicalVars, _AllAliases) ->
+collect_alias_collision_errors([], _CanonicalVarSet, []) ->
     ok;
-validate_alias_collisions([{Alias, OwnerVar} | Rest], CanonicalVars, AllAliases) ->
-    %% Check if alias collides with a canonical variable
-    case lists:keyfind(Alias, 1, CanonicalVars) of
-        {Alias, CollidingMapping} ->
-            CollidingVar = cuttlefish_mapping:variable(CollidingMapping),
-            {error, {alias_collision, {Alias, OwnerVar, CollidingVar}}};
+collect_alias_collision_errors([], _CanonicalVarSet, Errors) ->
+    {errorlist, lists:reverse(Errors)};
+collect_alias_collision_errors([{Alias, OwnerVar} | Rest], CanonicalVarSet, Errors) ->
+    AliasStr = cuttlefish_variable:format(Alias),
+    OwnerStr = cuttlefish_variable:format(OwnerVar),
+    NewErrors = case sets:is_element(Alias, CanonicalVarSet) of
+        true ->
+            [{error, {alias_shadows_canonical, {AliasStr, OwnerStr}}} | Errors];
         false ->
-            %% Check if alias collides with another mapping's alias
-            OtherAliases = [{A, V} || {A, V} <- AllAliases, V =/= OwnerVar],
-            case lists:keyfind(Alias, 1, OtherAliases) of
+            OtherMappingAliases = [{A, V} || {A, V} <- Rest, V =/= OwnerVar],
+            case lists:keyfind(Alias, 1, OtherMappingAliases) of
                 {Alias, OtherOwnerVar} ->
-                    {error, {alias_collision, {Alias, OwnerVar, OtherOwnerVar}}};
+                    OtherStr = cuttlefish_variable:format(OtherOwnerVar),
+                    [{error, {alias_claimed_by_multiple_mappings, {AliasStr, OwnerStr, OtherStr}}} | Errors];
                 false ->
-                    validate_alias_collisions(Rest, CanonicalVars, AllAliases)
+                    Errors
             end
-    end.
+    end,
+    collect_alias_collision_errors(Rest, CanonicalVarSet, NewErrors).
 
 count_mappings(Mappings) ->
     lists:foldl(
@@ -555,19 +553,31 @@ merge_across_multiple_schemas_test() ->
 
 %% Alias collision tests
 
-alias_collision_with_canonical_test() ->
-    %% Alias collides with another mapping's canonical variable
+alias_shadows_canonical_test() ->
     String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"c.d\"]}]}.\n"
           ++ "{mapping, \"c.d\", \"e.j\", []}.\n",
     Result = strings([String]),
-    ?assertMatch({errorlist, [{error, {alias_collision, _}}]}, Result).
+    ?assertMatch({errorlist, [{error, {alias_shadows_canonical, {"c.d", "a.b"}}}]}, Result).
 
-alias_collision_between_aliases_test() ->
-    %% Same alias claimed by two different mappings
+alias_claimed_by_multiple_mappings_test() ->
     String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.key\"]}]}.\n"
           ++ "{mapping, \"c.d\", \"e.j\", [{aliases, [\"old.key\"]}]}.\n",
     Result = strings([String]),
-    ?assertMatch({errorlist, [{error, {alias_collision, _}}]}, Result).
+    ?assertMatch({errorlist,
+        [{error, {alias_claimed_by_multiple_mappings, {"old.key", "a.b", "c.d"}}}]}, Result).
+
+alias_multiple_collisions_reported_test() ->
+    %% Two independent shadow collisions: both should be reported
+    String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.x\"]}]}.\n"
+          ++ "{mapping, \"c.d\", \"e.j\", [{aliases, [\"old.y\"]}]}.\n"
+          ++ "{mapping, \"old.x\", \"e.m\", []}.\n"
+          ++ "{mapping, \"old.y\", \"e.n\", []}.\n",
+    {errorlist, Errors} = strings([String]),
+    ?assertEqual(2, length(Errors)),
+    ?assert(lists:any(fun({error, {alias_shadows_canonical, {"old.x", _}}}) -> true;
+                         (_) -> false end, Errors)),
+    ?assert(lists:any(fun({error, {alias_shadows_canonical, {"old.y", _}}}) -> true;
+                         (_) -> false end, Errors)).
 
 alias_no_collision_test() ->
     %% Different aliases, no collision
@@ -583,5 +593,16 @@ alias_no_collision_same_mapping_test() ->
     ?assertEqual(1, length(Mappings)),
     [M] = Mappings,
     ?assertEqual([["old", "ab"], ["older", "ab"]], cuttlefish_mapping:aliases(M)).
+
+alias_singular_from_schema_string_test() ->
+    String = "{mapping, \"new.key\", \"app.setting\", [{alias, \"old.key\"}]}.\n",
+    {_, [M], _} = strings([String]),
+    ?assertEqual([["old", "key"]], cuttlefish_mapping:aliases(M)).
+
+alias_shadows_canonical_across_schema_strings_test() ->
+    Schema1 = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.key\"]}]}.\n",
+    Schema2 = "{mapping, \"old.key\", \"e.j\", []}.\n",
+    Result = strings([Schema1, Schema2]),
+    ?assertMatch({errorlist, [{error, {alias_shadows_canonical, {"old.key", "a.b"}}}]}, Result).
 
 -endif.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -108,7 +108,49 @@ filter({Translations, Mappings, Validators}) ->
         end,
         Mappings, MappingsToCheck),
 
-    {Translations, NewMappings, Validators}.
+    case validate_aliases(NewMappings) of
+        ok ->
+            {Translations, NewMappings, Validators};
+        {error, _} = Error ->
+            {errorlist, [Error]}
+    end.
+
+%% @doc Validates that aliases don't collide with other mappings' canonical
+%% variables or with aliases from other mappings.
+-spec validate_aliases([cuttlefish_mapping:mapping()]) -> ok | cuttlefish_error:error().
+validate_aliases(Mappings) ->
+    %% Build an index of all canonical variables
+    CanonicalVars = [{cuttlefish_mapping:variable(M), M} || M <- Mappings],
+    %% Build an index of all aliases -> owning mapping
+    AliasIndex = lists:foldl(fun(M, Acc) ->
+        Variable = cuttlefish_mapping:variable(M),
+        Aliases = cuttlefish_mapping:aliases(M),
+        lists:foldl(fun(Alias, InnerAcc) ->
+            [{Alias, Variable} | InnerAcc]
+        end, Acc, Aliases)
+    end, [], Mappings),
+
+    %% Check for collisions
+    validate_alias_collisions(AliasIndex, CanonicalVars, AliasIndex).
+
+validate_alias_collisions([], _CanonicalVars, _AllAliases) ->
+    ok;
+validate_alias_collisions([{Alias, OwnerVar} | Rest], CanonicalVars, AllAliases) ->
+    %% Check if alias collides with a canonical variable
+    case lists:keyfind(Alias, 1, CanonicalVars) of
+        {Alias, CollidingMapping} ->
+            CollidingVar = cuttlefish_mapping:variable(CollidingMapping),
+            {error, {alias_collision, {Alias, OwnerVar, CollidingVar}}};
+        false ->
+            %% Check if alias collides with another mapping's alias
+            OtherAliases = [{A, V} || {A, V} <- AllAliases, V =/= OwnerVar],
+            case lists:keyfind(Alias, 1, OtherAliases) of
+                {Alias, OtherOwnerVar} ->
+                    {error, {alias_collision, {Alias, OwnerVar, OtherOwnerVar}}};
+                false ->
+                    validate_alias_collisions(Rest, CanonicalVars, AllAliases)
+            end
+    end.
 
 count_mappings(Mappings) ->
     lists:foldl(
@@ -510,5 +552,36 @@ merge_across_multiple_schemas_test() ->
     ?assertEqual(on, cuttlefish_mapping:default(Mapping)),
     ?assertEqual(["hi"], cuttlefish_mapping:doc(Mapping)),
     ok.
+
+%% Alias collision tests
+
+alias_collision_with_canonical_test() ->
+    %% Alias collides with another mapping's canonical variable
+    String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"c.d\"]}]}.\n"
+          ++ "{mapping, \"c.d\", \"e.j\", []}.\n",
+    Result = strings([String]),
+    ?assertMatch({errorlist, [{error, {alias_collision, _}}]}, Result).
+
+alias_collision_between_aliases_test() ->
+    %% Same alias claimed by two different mappings
+    String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.key\"]}]}.\n"
+          ++ "{mapping, \"c.d\", \"e.j\", [{aliases, [\"old.key\"]}]}.\n",
+    Result = strings([String]),
+    ?assertMatch({errorlist, [{error, {alias_collision, _}}]}, Result).
+
+alias_no_collision_test() ->
+    %% Different aliases, no collision
+    String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.ab\"]}]}.\n"
+          ++ "{mapping, \"c.d\", \"e.j\", [{aliases, [\"old.cd\"]}]}.\n",
+    {_, Mappings, _} = strings([String]),
+    ?assertEqual(2, length(Mappings)).
+
+alias_no_collision_same_mapping_test() ->
+    %% Multiple aliases on same mapping is fine
+    String = "{mapping, \"a.b\", \"e.k\", [{aliases, [\"old.ab\", \"older.ab\"]}]}.\n",
+    {_, Mappings, _} = strings([String]),
+    ?assertEqual(1, length(Mappings)),
+    [M] = Mappings,
+    ?assertEqual([["old", "ab"], ["older", "ab"]], cuttlefish_mapping:aliases(M)).
 
 -endif.

--- a/test/cuttlefish_alias_proper_tests.erl
+++ b/test/cuttlefish_alias_proper_tests.erl
@@ -1,0 +1,263 @@
+-module(cuttlefish_alias_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 500}, {to_file, user}]))).
+
+%%
+%% Test entry points
+%%
+
+idempotent_test() -> ?PROP(prop_idempotent()).
+length_test()     -> ?PROP(prop_length()).
+no_alias_keys_survive_test() -> ?PROP(prop_no_alias_keys_survive()).
+canonical_preserved_test()   -> ?PROP(prop_canonical_preserved()).
+alias_value_promoted_test()  -> ?PROP(prop_alias_value_promoted()).
+
+multi_alias_idempotent_test()          -> ?PROP(prop_multi_alias_idempotent()).
+multi_alias_no_alias_keys_survive_test() -> ?PROP(prop_multi_alias_no_alias_keys_survive()).
+multi_alias_first_wins_test()          -> ?PROP(prop_multi_alias_first_wins()).
+
+%%
+%% Properties — single alias per mapping
+%%
+
+%% Alias resolution is idempotent: after the first pass all aliases are
+%% gone, so a second pass is a no-op.
+prop_idempotent() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_aliases(),
+        begin
+            Once = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            Twice = cuttlefish_generator:resolve_aliases(Once, Mappings),
+            Once =:= Twice
+        end).
+
+%% Alias resolution never grows the conf. It rewrites keys (length
+%% unchanged) or drops them (length shrinks). It never adds entries.
+prop_length() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            length(Resolved) =< length(Conf)
+        end).
+
+%% No alias keys survive resolution.
+prop_no_alias_keys_survive() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            AllAliases = lists:flatmap(
+                fun cuttlefish_mapping:aliases/1, Mappings),
+            ResolvedKeys = [K || {K, _} <- Resolved],
+            lists:all(
+                fun(A) -> not lists:member(A, ResolvedKeys) end,
+                AllAliases)
+        end).
+
+%% If the canonical key is present in the input, it is present with the
+%% same value in the output.
+prop_canonical_preserved() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            lists:all(fun(Mapping) ->
+                Canonical = cuttlefish_mapping:variable(Mapping),
+                case proplists:get_value(Canonical, Conf) of
+                    undefined -> true;
+                    Val -> proplists:get_value(Canonical, Resolved) =:= Val
+                end
+            end, Mappings)
+        end).
+
+%% When only an alias is set (canonical absent), the resolved conf
+%% contains the alias's value under the canonical key.
+prop_alias_value_promoted() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            lists:all(fun(Mapping) ->
+                Canonical = cuttlefish_mapping:variable(Mapping),
+                [Alias] = cuttlefish_mapping:aliases(Mapping),
+                CanonicalInInput = proplists:get_value(Canonical, Conf),
+                AliasInInput = proplists:get_value(Alias, Conf),
+                case {CanonicalInInput, AliasInInput} of
+                    {undefined, undefined} -> true;
+                    {undefined, AliasVal} ->
+                        proplists:get_value(Canonical, Resolved) =:= AliasVal;
+                    {_, _} -> true %% canonical-wins tested by prop_canonical_preserved
+                end
+            end, Mappings)
+        end).
+
+%%
+%% Properties — multiple aliases per mapping
+%%
+
+prop_multi_alias_idempotent() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_multi_aliases(),
+        begin
+            Once = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            Twice = cuttlefish_generator:resolve_aliases(Once, Mappings),
+            Once =:= Twice
+        end).
+
+prop_multi_alias_no_alias_keys_survive() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_multi_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            AllAliases = lists:flatmap(
+                fun cuttlefish_mapping:aliases/1, Mappings),
+            ResolvedKeys = [K || {K, _} <- Resolved],
+            lists:all(
+                fun(A) -> not lists:member(A, ResolvedKeys) end,
+                AllAliases)
+        end).
+
+%% When canonical is not set and multiple aliases are, the first alias
+%% in declaration order wins.
+prop_multi_alias_first_wins() ->
+    ?FORALL({Conf, Mappings}, gen_conf_with_multi_aliases(),
+        begin
+            Resolved = cuttlefish_generator:resolve_aliases(Conf, Mappings),
+            lists:all(fun(Mapping) ->
+                Canonical = cuttlefish_mapping:variable(Mapping),
+                Aliases = cuttlefish_mapping:aliases(Mapping),
+                CanonicalInInput = proplists:get_value(Canonical, Conf),
+                case CanonicalInInput of
+                    undefined ->
+                        %% Find the first set alias
+                        FirstSetAlias = lists:dropwhile(
+                            fun(A) -> proplists:get_value(A, Conf) =:= undefined end,
+                            Aliases),
+                        case FirstSetAlias of
+                            [] -> true;
+                            [Winner|_] ->
+                                ExpectedVal = proplists:get_value(Winner, Conf),
+                                proplists:get_value(Canonical, Resolved) =:= ExpectedVal
+                        end;
+                    _ -> true
+                end
+            end, Mappings)
+        end).
+
+%%
+%% Generators
+%%
+
+gen_segment() ->
+    ?LET(S, non_empty(list(oneof([choose($a, $z), choose($0, $9)]))),
+         S).
+
+gen_conf_key() ->
+    ?LET(Segments, non_empty(list(gen_segment())),
+         Segments).
+
+%% Which conf entries to include for a single-alias mapping:
+%%   canonical only, alias only, both, or neither.
+gen_conf_entry_choice() ->
+    elements([canonical_only, alias_only, both, neither]).
+
+%% Single-alias generator: each mapping has exactly one alias.
+gen_conf_with_aliases() ->
+    ?LET(N, range(1, 5),
+        ?SUCHTHAT({_Conf, Mappings}, gen_conf_with_aliases_raw(N),
+            Mappings =/= [])).
+
+gen_conf_with_aliases_raw(N) ->
+    ?LET(Pairs, vector(N, {gen_conf_key(), gen_conf_key()}),
+        begin
+            {UniquePairs, _Seen} = deduplicate_keys(Pairs),
+            Mappings = [cuttlefish_mapping:parse(
+                {mapping,
+                 cuttlefish_variable:format(Canonical),
+                 "app." ++ cuttlefish_variable:format(Canonical),
+                 [{datatype, string},
+                  {aliases, [cuttlefish_variable:format(Alias)]}]}
+            ) || {Canonical, Alias} <- UniquePairs],
+            ?LET(Choices, vector(length(UniquePairs), gen_conf_entry_choice()),
+                begin
+                    Conf = lists:flatmap(fun({{Canonical, Alias}, Choice}) ->
+                        case Choice of
+                            canonical_only -> [{Canonical, "canonical_val"}];
+                            alias_only     -> [{Alias, "alias_val"}];
+                            both           -> [{Canonical, "canonical_val"},
+                                               {Alias, "alias_val"}];
+                            neither        -> []
+                        end
+                    end, lists:zip(UniquePairs, Choices)),
+                    {Conf, Mappings}
+                end)
+        end).
+
+%% Multi-alias generator: each mapping has 1-3 aliases.
+gen_conf_with_multi_aliases() ->
+    ?LET(N, range(1, 3),
+        ?SUCHTHAT({_Conf, Mappings}, gen_conf_with_multi_aliases_raw(N),
+            Mappings =/= [])).
+
+gen_alias_keys() ->
+    ?LET(Count, range(1, 3),
+        vector(Count, gen_conf_key())).
+
+gen_conf_with_multi_aliases_raw(N) ->
+    ?LET(Groups, vector(N, {gen_conf_key(), gen_alias_keys()}),
+        begin
+            %% Flatten all keys (canonical + all aliases) for dedup
+            {UniqueGroups, _Seen} = lists:foldl(fun({C, As}, {Acc, Seen}) ->
+                AllKeys = [C | As],
+                HasCollision = lists:any(fun(K) -> lists:member(K, Seen) end, AllKeys)
+                    orelse length(lists:usort(AllKeys)) =/= length(AllKeys),
+                case HasCollision of
+                    true  -> {Acc, Seen};
+                    false -> {[{C, As} | Acc], AllKeys ++ Seen}
+                end
+            end, {[], []}, Groups),
+
+            Mappings = [cuttlefish_mapping:parse(
+                {mapping,
+                 cuttlefish_variable:format(Canonical),
+                 "app." ++ cuttlefish_variable:format(Canonical),
+                 [{datatype, string},
+                  {aliases, [cuttlefish_variable:format(A) || A <- Aliases]}]}
+            ) || {Canonical, Aliases} <- UniqueGroups],
+
+            %% Generate a boolean for each key (canonical + each alias)
+            %% to decide whether to include it in conf
+            AllKeyLists = [begin
+                AliasIndexed = lists:zip(Aliases, lists:seq(1, length(Aliases))),
+                {Canonical, AliasIndexed}
+            end || {Canonical, Aliases} <- UniqueGroups],
+            TotalBools = lists:sum([1 + length(As) || {_, As} <- UniqueGroups]),
+            ?LET(Bools, vector(TotalBools, boolean()),
+                begin
+                    {Conf, _} = lists:foldl(fun({Canonical, AliasIndexed}, {ConfAcc, BoolsAcc}) ->
+                        [IncludeCanonical | Rest1] = BoolsAcc,
+                        {AliasEntries, Rest2} = lists:foldl(
+                            fun({A, I}, {Entries, [B|Bs]}) ->
+                                case B of
+                                    true -> {[{A, "alias_val_" ++ integer_to_list(I)} | Entries], Bs};
+                                    false -> {Entries, Bs}
+                                end
+                            end, {[], Rest1}, AliasIndexed),
+                        CanonicalEntries = case IncludeCanonical of
+                            true -> [{Canonical, "canonical_val"}];
+                            false -> []
+                        end,
+                        {ConfAcc ++ CanonicalEntries ++ lists:reverse(AliasEntries), Rest2}
+                    end, {[], Bools}, AllKeyLists),
+                    {Conf, Mappings}
+                end)
+        end).
+
+%% Helpers
+
+deduplicate_keys(Pairs) ->
+    lists:foldl(fun({C, A}, {Acc, Seen}) ->
+        case lists:member(C, Seen) orelse
+             lists:member(A, Seen) orelse
+             C =:= A of
+            true  -> {Acc, Seen};
+            false -> {[{C, A} | Acc], [C, A | Seen]}
+        end
+    end, {[], []}, Pairs).


### PR DESCRIPTION
This implements the design in #69 with a few deviations or additions:

1. `alias` is a single string key property accepted as a common alternative to `aliases`, an array of strings
2. This PR adds a few property-based test suites
3. Conflicting aliases are considered to be schema integrity errors
4. Conflicting canonical keys and aliases are resolved like so: the canonical (original) value wins
5. Conflicting values on alias lists are resolved in an equally straightforward manner: the first value on the list wins
6. `{aliases, []}` in a merge mapping is a deliberate "clear all aliases" directive - it clears aliases inherited from the base mapping. This is intentionally asymmetric with `see` and `doc`, where an empty list in a merge mapping means "not specified, inherit".

## RHS Substitution Limitation

Alias keys are rewritten to their canonical keys early in the pipeline, before RHS substitutions are evaluated. This means `$(old.key)` in a substitution will fail if `old.key` is an alias - use `$(new.key)` instead. Cuttlefish will emit a specific error message identifying the alias and naming the canonical key to use.

## A Realistic Example

In this hypothetical (for now anyway) scenario, assume that Team RabbitMQ
wants to move a few `rabbitmq.conf` keys under the `raft.quorum_queue.*` namespace (`raft.{subsystem}.{key}`, if we generalize).

Today this requires duplicating the mapping and writing boilerplate translations
for every key, and making sure you get it right every time:

```erl
{mapping, "raft.quorum_queue.segment_max_entries", "ra.segment_max_entries", [
    {datatype, integer},
    {validators, ["non_zero_positive_integer", "positive_16_bit_unsigned_integer"]}
]}.
{mapping, "raft.segment_max_entries", "ra.segment_max_entries", [
    {datatype, integer}
]}.
{translation, "ra.segment_max_entries", fun(Conf) ->
    case cuttlefish:conf_get("raft.quorum_queue.segment_max_entries", Conf, undefined) of
        undefined -> cuttlefish:conf_get("raft.segment_max_entries", Conf, cuttlefish:unset());
        Value     -> Value
    end
end}.
```

With aliases, the old keys just work and the implementation is dramatically less error-prone:

```erl
{mapping, "raft.quorum_queue.segment_max_entries", "ra.segment_max_entries", [
    {datatype, integer},
    {validators, ["non_zero_positive_integer", "positive_16_bit_unsigned_integer"]},
    %% a shortcut for {aliases, ["raft.wal_max_size_bytes"]}
    {alias, "raft.wal_max_size_bytes"}
]}.
```

## A Basic Conflict Resolution Example

If both the canonical key and the alias are set, the canonical key takes precedence:

```ini
# rabbitmq.conf
raft.quorum_queue.wal_max_size_bytes = 536870912
raft.wal_max_size_bytes = 268435456
```

```erl
{mapping, "raft.quorum_queue.wal_max_size_bytes", "ra.wal_max_size_bytes", [
    {datatype, integer},
    {validators, ["non_zero_positive_integer"]},
    {alias, "raft.wal_max_size_bytes"}
]}.
```

The outcome: the value of 536870912 will be used, and Cuttlefish will emit a warning:

```
raft.wal_max_size_bytes is deprecated and ignored in favor of raft.quorum_queue.wal_max_size_bytes
```

## Other Comments

Closes #69.
