### PR TITLE
First class support for collections (heavily inspired by RabbitMQ's use of Cuttlefish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v3.7.0](https://github.com/Kyorai/cuttlefish/tree/v3.7.0) (unreleased)
+
+[Full Changelog](https://github.com/Kyorai/cuttlefish/compare/v3.6.0...v3.7.0)
+
+**Merged pull requests:**
+
+- First class support for collections [\#73](https://github.com/Kyorai/cuttlefish/pull/73) ([michaelklishin](https://github.com/michaelklishin))
+- Alias support for deprecated conf keys [\#70](https://github.com/Kyorai/cuttlefish/pull/70) ([michaelklishin](https://github.com/michaelklishin))
+- Miscellaneous fixes: dialyzer, error propagation, test robustness [\#71](https://github.com/Kyorai/cuttlefish/pull/71) ([lukebakken](https://github.com/lukebakken))
+
 ## [v3.6.0](https://github.com/Kyorai/cuttlefish/tree/v3.6.0) (2025-10-29)
 
 [Full Changelog](https://github.com/Kyorai/cuttlefish/compare/v3.5.0...v3.6.0)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,532 @@
+# Cuttlefish Reference
+
+This document is the comprehensive reference for schema authors. It covers the schema file format, all mapping options, all datatypes, the translation and validator systems, and the helper functions available inside translation functions.
+
+## Table of Contents
+
+- [Schema Files](#schema-files)
+- [Mappings](#mappings)
+  - [Mapping Options](#mapping-options)
+  - [Fuzzy Variables](#fuzzy-variables)
+  - [Aliases](#aliases)
+  - [Collections](#collections)
+- [Datatypes](#datatypes)
+- [Translations](#translations)
+- [Validators](#validators)
+- [Helper Functions](#helper-functions)
+- [The conf File Format](#the-conf-file-format)
+- [The Pipeline](#the-pipeline)
+
+---
+
+## Schema Files
+
+A schema file is a plain Erlang terms file (parsed with `erl_scan`/`erl_parse`). Each term is one of three types:
+
+```erlang
+{mapping, "conf.key", "app.erlang_key", [Options]}.
+{translation, "app.erlang_key", fun(Conf) -> ... end}.
+{validator, "name", "description", fun(Value) -> boolean() end}.
+```
+
+Multiple schema files can be loaded together. Later files can override earlier ones using the `merge` option. Schema files are loaded via `cuttlefish_schema:files/1` or `cuttlefish_schema:strings/1`.
+
+---
+
+## Mappings
+
+A mapping connects a conf file key to an Erlang app.config key.
+
+```erlang
+{mapping, "ring_size", "riak_core.ring_creation_size", [
+    {datatype, integer},
+    {default, 64},
+    {doc, ["The number of partitions in the ring."]}
+]}.
+```
+
+The first argument is the conf key (dot-separated string). The second is the Erlang app.config path (also dot-separated; the first segment is the application name). The third is a proplist of options.
+
+### Mapping Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `{datatype, T}` | datatype or list of datatypes | Type(s) for parsing and validation. See [Datatypes](#datatypes). |
+| `{default, V}` | any Erlang term | Value used when the key is absent from the conf file. |
+| `{commented, V}` | any Erlang term | Like `default`, but the key is commented out in the generated conf file. |
+| `{level, L}` | `basic`, `intermediate`, or `advanced` | Controls which keys appear in the generated conf file. Defaults to `basic`. |
+| `{doc, [String]}` | list of strings | Documentation lines shown in the generated conf file. |
+| `{validators, [Name]}` | list of strings | Named validators to run against the parsed value. |
+| `{hidden, true}` | boolean | Omit this key from the generated conf file entirely. |
+| `{alias, "old.key"}` | string | A single deprecated conf key that maps to this mapping. See [Aliases](#aliases). |
+| `{aliases, ["old.key"]}` | list of strings | Multiple deprecated conf keys. See [Aliases](#aliases). |
+| `{collect, Type}` | collect type | Auto-collect fuzzy variable matches into a list, map, or proplist. See [Collections](#collections). |
+| `{see, ["other.key"]}` | list of strings | Cross-references to related conf keys, shown in generated conf. |
+| `{include_default, "name"}` | string | Includes a named default value in the generated conf. |
+| `merge` | atom | Merge this mapping with an existing mapping of the same variable rather than replacing it. Used when multiple schema files contribute to the same key. |
+
+### Fuzzy Variables
+
+A conf key segment prefixed with `$` is a fuzzy variable - it acts as a wildcard matching any value in that position.
+
+```erlang
+{mapping, "listener.tcp.$name", "ranch.tcp_listeners", [
+    {datatype, integer}
+]}.
+```
+
+This matches `listener.tcp.default`, `listener.tcp.internal`, etc. The `$name` segment captures the concrete value. Fuzzy variables are used with translations (to collect all matching values) or with the `{collect, Type}` option (to auto-collect without a translation).
+
+Fuzzy variables are not supported in aliases.
+
+### Aliases
+
+Aliases allow a mapping to transparently accept deprecated conf keys. When a user's conf file contains an alias key, cuttlefish rewrites it to the canonical key and logs a deprecation warning.
+
+```erlang
+{mapping, "new.key", "app.setting", [
+    {datatype, integer},
+    {default, 42},
+    {alias, "old.key"}
+]}.
+```
+
+Multiple aliases:
+
+```erlang
+{mapping, "new.key", "app.setting", [
+    {datatype, integer},
+    {alias, "old.key"},
+    {aliases, ["older.key", "oldest.key"]}
+]}.
+```
+
+**Behavior:**
+
+- Alias resolution runs before defaults and substitutions.
+- If both the canonical key and an alias key are present in the conf file, the canonical key wins.
+- If multiple alias keys are present and the canonical key is absent, the first alias in declaration order wins.
+- Using `$(old.key)` in an RHS substitution is an error. Use `$(new.key)` instead.
+- Aliases on fuzzy variables are not supported and are rejected at schema load time.
+- In a merge mapping, `{aliases, []}` explicitly clears all inherited aliases.
+
+**Validation at schema load time:**
+
+- An alias key that shadows a canonical key is rejected.
+- An alias key claimed by two different mappings is rejected.
+
+### Collections
+
+The `{collect, Type}` option eliminates the boilerplate translation function required for fuzzy-variable mappings that collect values into a list, map, or proplist.
+
+**Supported collection types:**
+
+| Type | Erlang result | Key conversion |
+|------|---------------|----------------|
+| `list` | `[Value]` | none - values sorted by wildcard segment |
+| `{map, atom}` | `#{atom() => Value}` | `list_to_atom/1` |
+| `{map, binary}` | `#{binary() => Value}` | `list_to_binary/1` |
+| `{proplist, atom}` | `[{atom(), Value}]` | `list_to_atom/1`, sorted by wildcard segment |
+
+**Example - replacing an explicit translation:**
+
+Before:
+
+```erlang
+{mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
+    {datatype, atom}
+]}.
+
+{translation, "rabbit.auth_mechanisms",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_mechanisms", Conf),
+    Sorted = lists:keysort(1, Settings),
+    [V || {_, V} <- Sorted]
+end}.
+```
+
+After:
+
+```erlang
+{mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
+    {datatype, atom},
+    {collect, list}
+]}.
+```
+
+**Sorting:** For `list` and `{proplist, atom}`, values are sorted lexicographically by the wildcard segment value (e.g. the `$name` part). For a single-segment fuzzy variable this produces the same order as `lists:keysort/1` on the full conf key.
+
+**Empty result:** When no conf values match the wildcard pattern, the key is absent from the generated app.config (equivalent to calling `cuttlefish:unset()` in a translation). This differs from a translation that returns `[]`, which writes an empty list to app.config.
+
+**Translation takes precedence:** If a translation exists for the same Erlang app.config key, the translation always runs and `{collect, Type}` is ignored. This means existing schemas with translations are unaffected when `{collect, Type}` is added to a mapping.
+
+**Constraints:**
+
+- `{collect, Type}` requires exactly one fuzzy (`$`) segment in the variable name. Zero or more than one wildcard is a schema load-time error.
+- `{proplist, binary}` is not a supported collection type.
+
+---
+
+## Datatypes
+
+The `{datatype, T}` option specifies how a conf string value is parsed into an Erlang term. Multiple datatypes can be specified as a list; cuttlefish tries each in order and uses the first that succeeds.
+
+### `integer`
+
+Parses a decimal integer string. Erlang type: `integer()`.
+
+```
+ring_size = 64
+```
+
+### `string`
+
+Passes the value through as-is. Erlang type: `string()` (charlist).
+
+```
+node.name = riak@127.0.0.1
+```
+
+### `binary`
+
+Converts the string to a binary. Erlang type: `binary()`.
+
+```
+secret.key = mysecret
+```
+
+### `atom`
+
+Converts the string to an atom via `list_to_atom/1`. Erlang type: `atom()`.
+
+```
+storage_backend = bitcask
+```
+
+### `float`
+
+Parses a floating-point string. Erlang type: `float()`.
+
+```
+threshold = 0.75
+```
+
+### `flag`
+
+Parses `on`/`off` to `true`/`false`. Erlang type: `boolean()`.
+
+```
+log.syslog = on
+```
+
+Custom on/off atoms:
+
+```erlang
+{datatype, {flag, enabled, disabled}}
+```
+
+Parses `enabled`/`disabled` to `true`/`false`.
+
+Custom on/off values:
+
+```erlang
+{datatype, {flag, {on, tyk}, {off, torp}}}
+```
+
+Parses `on`/`off` to `tyk`/`torp`.
+
+### `{enum, [atom()]}`
+
+Parses one of a fixed set of atom values.
+
+```erlang
+{datatype, {enum, [debug, info, warning, error]}}
+```
+
+```
+log.level = info
+```
+
+Erlang type: `atom()`.
+
+### `ip`
+
+Parses an `IP:Port` string. Erlang type: `{string(), integer()}`.
+
+```
+listener.http.internal = 127.0.0.1:8098
+```
+
+### `fqdn`
+
+Parses a hostname with optional port. Erlang type: `string()` or `{string(), integer()}`.
+
+```
+amqp.hostname = rabbit.example.com:5672
+```
+
+### `domain_socket`
+
+Parses a Unix domain socket path. Accepts either a plain path string or `local:PATH:PORT` format. Erlang type: `string()` or `{local, string(), integer()}`.
+
+```
+listener.unix = /var/run/app.sock
+listener.unix = local:/var/run/app.sock:0
+```
+
+### `bytesize`
+
+Parses a byte size with optional unit suffix (`KB`, `MB`, `GB`). Case-insensitive. Erlang type: `integer()` (bytes).
+
+```
+object.size.maximum = 50MB
+```
+
+### `{duration, Unit}`
+
+Parses a duration string (e.g. `5s`, `2h30m`). Erlang type: `integer()` (in the specified unit).
+
+Units: `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `f` (fortnights).
+
+```erlang
+{datatype, {duration, ms}}
+```
+
+```
+handoff.timeout = 30s
+```
+
+### `{percent, integer}` and `{percent, float}`
+
+Parses a percentage string ending in `%`. `{percent, integer}` produces an `integer()` in the range 0-100. `{percent, float}` produces a `float()` in the range 0.0-1.0.
+
+```
+cache.fill.ratio = 75%
+```
+
+### `tagged_string`
+
+Parses a `tag:value` string where the tag is alphanumeric (plus underscores). Erlang type: `{atom(), string()}`.
+
+```
+credential = plain:mypassword
+```
+
+### `tagged_binary`
+
+Like `tagged_string` but the value part is returned as a binary. Erlang type: `{atom(), binary()}`.
+
+### `{list, T}`
+
+Parses a comma-separated list of values, each parsed as datatype `T`. Erlang type: `[T]`. Lists of lists are not supported.
+
+```erlang
+{datatype, {list, atom}}
+```
+
+```
+plugins = plugin_a, plugin_b, plugin_c
+```
+
+### `file` and `directory`
+
+Pass the value through as a string. Semantically indicate that the value is a filesystem path. Erlang type: `string()`.
+
+---
+
+## Translations
+
+A translation converts one or more conf values into a final Erlang app.config value. Translations run after datatype conversion, so values in `Conf` are already typed Erlang terms.
+
+```erlang
+{translation, "app.erlang_key",
+fun(Conf) ->
+    Value = cuttlefish:conf_get("some.conf.key", Conf),
+    transform(Value)
+end}.
+```
+
+The translation function receives the full typed conf proplist. It must return the Erlang value to write to app.config.
+
+To omit the key from app.config entirely, call `cuttlefish:unset/0`. To report invalid input, call `cuttlefish:invalid/1,2`. Both are throws caught by the pipeline.
+
+When a translation exists for an Erlang key, it takes precedence over any direct 1:1 mapping to that key.
+
+---
+
+## Validators
+
+A validator is a named predicate applied to a parsed value before translations run.
+
+```erlang
+{validator, "positive_integer", "must be a positive integer",
+fun(Value) ->
+    Value > 0
+end}.
+```
+
+Reference validators by name in a mapping's `validators` list:
+
+```erlang
+{mapping, "ring_size", "riak_core.ring_creation_size", [
+    {datatype, integer},
+    {validators, ["positive_integer"]}
+]}.
+```
+
+The validator function receives the typed value (after datatype conversion). Return `true` to pass, `false` to fail. On failure, cuttlefish reports the validator description as the error message.
+
+---
+
+## Helper Functions
+
+These functions are available inside translation functions via the `cuttlefish` module.
+
+### `cuttlefish:conf_get/2`
+
+```erlang
+cuttlefish:conf_get(Key, Conf) -> Value
+```
+
+Looks up `Key` in `Conf`. `Key` can be a dot-separated string or a tokenized variable list. Throws `{not_found, Key}` if the key is absent, which aborts the translation. Use `conf_get/3` if you want a default instead.
+
+### `cuttlefish:conf_get/3`
+
+```erlang
+cuttlefish:conf_get(Key, Conf, Default) -> Value
+```
+
+Like `conf_get/2` but returns `Default` instead of throwing when the key is absent.
+
+### `cuttlefish:unset/0`
+
+```erlang
+cuttlefish:unset() -> no_return()
+```
+
+Call inside a translation to omit the Erlang key from the generated app.config entirely.
+
+### `cuttlefish:invalid/1,2`
+
+```erlang
+cuttlefish:invalid(Reason :: string()) -> no_return()
+cuttlefish:invalid(Fmt :: io:format(), Args :: [term()]) -> no_return()
+```
+
+Call inside a translation to report that the configuration is invalid. `Reason` is shown to the user.
+
+### `cuttlefish:warn/1,2`
+
+```erlang
+cuttlefish:warn(Message :: iodata()) -> ok
+cuttlefish:warn(Fmt :: io:format(), Args :: [term()]) -> ok
+```
+
+Call inside a translation to log a warning without aborting.
+
+### `cuttlefish:otp/2,3`
+
+```erlang
+cuttlefish:otp(MinVersion :: string(), IfGte :: any(), IfLt :: any()) -> any()
+cuttlefish:otp(MinVersion :: string(), ActualVersion :: string()) -> boolean()
+```
+
+OTP version comparison helper. Useful for generating version-dependent configuration.
+
+```erlang
+{translation, "app.ssl_opts",
+fun(Conf) ->
+    Base = [...],
+    cuttlefish:otp("26", [{versions, ['tlsv1.3', 'tlsv1.2']} | Base], Base)
+end}.
+```
+
+---
+
+## The conf File Format
+
+Conf files use a sysctl-style `key = value` syntax.
+
+```ini
+ring_size = 64
+log.error.file = /var/log/error.log
+log.syslog = on
+```
+
+### Comments
+
+Lines beginning with `#` are comments.
+
+```ini
+## This is a comment
+# This is also a comment
+ring_size = 64
+```
+
+### Multiline Values
+
+Values spanning multiple lines use triple single-quote delimiters (`'''`).
+
+```ini
+api.config = '''
+{
+  "endpoints": ["/health", "/metrics"],
+  "timeout": 30
+}
+'''
+```
+
+Leading and trailing newlines inside the delimiters are trimmed. Internal whitespace and newlines are preserved exactly.
+
+### Includes
+
+One conf file can include another:
+
+```ini
+include /etc/app/extra.conf
+```
+
+Glob patterns are supported:
+
+```ini
+include conf.d/*.conf
+```
+
+### RHS Substitutions
+
+A value can reference another conf key using `$(key)` syntax:
+
+```ini
+listener.http.internal = 127.0.0.1:8098
+listener.http.external = $(listener.http.internal)
+```
+
+Substitutions are resolved after alias rewriting. Using an alias key in a substitution (e.g. `$(old.key)`) is an error; use the canonical key instead.
+
+### Unicode BOM
+
+Conf files starting with a UTF-8, UTF-16 BE/LE, or UTF-32 BE/LE byte order mark are handled correctly. The BOM is stripped before parsing.
+
+---
+
+## The Pipeline
+
+Understanding the pipeline helps when debugging unexpected behavior.
+
+1. **Parse conf files** - `cuttlefish_conf:file/1` parses `.conf` into a `[{variable(), string()}]` proplist. Values are raw strings at this stage.
+
+2. **Load schema files** - `cuttlefish_schema:files/1` parses `.schema` files, merges them, validates aliases, and returns a `{[translation()], [mapping()], [validator()]}` tuple.
+
+3. **Resolve aliases** - Alias keys in conf are rewritten to their canonical keys. Deprecation warnings are logged. Canonical key wins if both are present.
+
+4. **Add defaults** - Schema defaults are injected for any key absent from conf.
+
+5. **Expand substitutions** - `$(key)` references in values are resolved.
+
+6. **Convert datatypes** - String values are converted to typed Erlang terms using each mapping's declared datatype.
+
+7. **Run validators** - Named validators are applied to typed values.
+
+8. **Run translations** - Translation functions produce the final Erlang values. Direct 1:1 mappings (and `{collect, Type}` mappings) are applied here as well.
+
+The output is a `[{AppName, [{Key, Value}]}]` proplist suitable for use as `app.config`.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -173,7 +173,16 @@ xlate({alias_shadows_canonical, {Alias, OwnerMapping}}) ->
                   [Alias, OwnerMapping, Alias]);
 xlate({alias_claimed_by_multiple_mappings, {Alias, Mapping1, Mapping2}}) ->
     io_lib:format("Alias ~ts is claimed by both ~ts and ~ts",
-                  [Alias, Mapping1, Mapping2]).
+                  [Alias, Mapping1, Mapping2]);
+xlate({invalid_collect_type, Value}) ->
+    io_lib:format("Invalid collect type ~tp. Valid types: list, {map, atom}, "
+                  "{map, binary}, {proplist, atom}", [Value]);
+xlate({collect_on_non_fuzzy, Variable}) ->
+    io_lib:format("collect property on mapping ~ts requires a wildcard ($) segment "
+                  "in the variable name", [Variable]);
+xlate({collect_multi_wildcard, Variable, N}) ->
+    io_lib:format("collect property on mapping ~ts has ~B wildcard segments; "
+                  "only a single wildcard is supported", [Variable, N]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -174,6 +174,9 @@ xlate({alias_shadows_canonical, {Alias, OwnerMapping}}) ->
 xlate({alias_claimed_by_multiple_mappings, {Alias, Mapping1, Mapping2}}) ->
     io_lib:format("Alias ~ts is claimed by both ~ts and ~ts",
                   [Alias, Mapping1, Mapping2]);
+xlate({unsupported_collect_type, {proplist, binary}}) ->
+    "collect type {proplist, binary} is not supported; "
+    "use {proplist, atom} for atom keys or {map, binary} for binary keys";
 xlate({invalid_collect_type, Value}) ->
     io_lib:format("Invalid collect type ~tp. Valid types: list, {map, atom}, "
                   "{map, binary}, {proplist, atom}", [Value]);

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -135,43 +135,108 @@ map_validate(Schema, Conf) ->
 -spec apply_mappings(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
                             {[proplists:property()], [string()]}.
 apply_mappings({Translations, Mappings, _Validators}, Conf) ->
-    %% This fold handles 1:1 mappings, that have no corresponding translations
+    %% This fold handles 1:1 mappings, that have no corresponding translations.
     %% The accumulator is the app.config proplist that we start building from
     %% these 1:1 mappings, hence the return "DirectMappings".
     %% It also builds a list of "TranslationsToDrop". It's basically saying that
     %% if a user didn't actually configure this setting in the .conf file and
     %% there's no default in the schema, then there won't be enough information
-    %% during the translation phase to succeed, so we'll earmark it to be skipped
+    %% during the translation phase to succeed, so we'll earmark it to be skipped.
+    %% Fuzzy mappings with a {collect, Type} property and no translation are
+    %% auto-collected here: all conf values matching the wildcard pattern are
+    %% assembled into a list, map, or proplist and written to app.config directly.
     {DirectMappings, {TranslationsToMaybeDrop, TranslationsToKeep}} = lists:foldr(
         fun(MappingRecord, {ConfAcc, {MaybeDrop, Keep}}) ->
             Mapping = cuttlefish_mapping:mapping(MappingRecord),
             Default = cuttlefish_mapping:default(MappingRecord),
             Variable = cuttlefish_mapping:variable(MappingRecord),
-            case {
-                Default =/= undefined orelse cuttlefish_conf:is_variable_defined(Variable, Conf),
-                lists:any(
-                    fun(T) ->
-                        cuttlefish_translation:mapping(T) =:= Mapping
-                    end,
-                    Translations)
-                } of
-                {true, false} ->
-                    Tokens = cuttlefish_variable:tokenize(Mapping),
-                    NewValue = proplists:get_value(Variable, Conf),
-                    {set_value(Tokens, ConfAcc, NewValue),
-                     {MaybeDrop, ordsets:add_element(Mapping,Keep)}};
-                {true, true} ->
-                    {ConfAcc, {MaybeDrop, ordsets:add_element(Mapping,Keep)}};
+            HasTranslation = lists:any(
+                fun(T) -> cuttlefish_translation:mapping(T) =:= Mapping end,
+                Translations),
+            CollectType = cuttlefish_mapping:collect(MappingRecord),
+            IsFuzzy = cuttlefish_mapping:is_fuzzy_variable(MappingRecord),
+            case {HasTranslation, CollectType =/= undefined andalso IsFuzzy} of
+                {false, true} ->
+                    collect_fuzzy_values(Variable, Mapping, CollectType, Conf,
+                                         ConfAcc, MaybeDrop, Keep);
                 _ ->
-                    {ConfAcc, {ordsets:add_element(Mapping,MaybeDrop), Keep}}
+                    case {Default =/= undefined orelse
+                          cuttlefish_conf:is_variable_defined(Variable, Conf),
+                          HasTranslation} of
+                        {true, false} ->
+                            Tokens = cuttlefish_variable:tokenize(Mapping),
+                            NewValue = proplists:get_value(Variable, Conf),
+                            {set_value(Tokens, ConfAcc, NewValue),
+                             {MaybeDrop, ordsets:add_element(Mapping, Keep)}};
+                        {true, true} ->
+                            {ConfAcc, {MaybeDrop, ordsets:add_element(Mapping, Keep)}};
+                        _ ->
+                            {ConfAcc, {ordsets:add_element(Mapping, MaybeDrop), Keep}}
+                    end
             end
         end,
-        {[], {ordsets:new(),ordsets:new()}},
+        {[], {ordsets:new(), ordsets:new()}},
         Mappings),
     _ = ?LOG_DEBUG("Applied 1:1 Mappings"),
 
     TranslationsToDrop = TranslationsToMaybeDrop -- TranslationsToKeep,
     {DirectMappings, TranslationsToDrop}.
+
+%% @doc Collects all conf values matching a fuzzy variable pattern and
+%% assembles them into the type specified by CollectType. Returns the
+%% accumulator unchanged when no conf values match the pattern (equivalent
+%% to the mapping producing no output, like cuttlefish:unset()).
+-spec collect_fuzzy_values(
+        cuttlefish_variable:variable(), string(),
+        cuttlefish_mapping:collect_type(),
+        cuttlefish_conf:conf(),
+        [proplists:property()], ordsets:ordset(string()), ordsets:ordset(string())) ->
+    {[proplists:property()], {ordsets:ordset(string()), ordsets:ordset(string())}}.
+collect_fuzzy_values(Variable, Mapping, CollectType, Conf, ConfAcc, MaybeDrop, Keep) ->
+    Matches = cuttlefish_variable:fuzzy_matches(Variable, Conf),
+    case Matches of
+        [] ->
+            {ConfAcc, {ordsets:add_element(Mapping, MaybeDrop), Keep}};
+        _ ->
+            Tokens = cuttlefish_variable:tokenize(Mapping),
+            Value = build_collect(Variable, Matches, CollectType, Conf),
+            {set_value(Tokens, ConfAcc, Value),
+             {MaybeDrop, ordsets:add_element(Mapping, Keep)}}
+    end.
+
+%% @doc Assembles a collection value from the set of fuzzy-matched conf
+%% entries. Matches is the output of cuttlefish_variable:fuzzy_matches/2:
+%% a list of {WildcardSegment, ConcreteSegmentValue} pairs. Values are
+%% sorted lexicographically by the wildcard segment value for list and
+%% proplist output types.
+-spec build_collect(
+        cuttlefish_variable:variable(),
+        [{string(), string()}],
+        cuttlefish_mapping:collect_type(),
+        cuttlefish_conf:conf()) -> term().
+build_collect(Variable, Matches, list, Conf) ->
+    Entries = [{SegVal,
+                proplists:get_value(
+                    cuttlefish_variable:replace_match(Variable, SegVal), Conf)}
+               || {_WildcardSeg, SegVal} <- Matches],
+    [V || {_, V} <- lists:sort(Entries)];
+build_collect(Variable, Matches, {map, atom}, Conf) ->
+    maps:from_list(
+        [{list_to_atom(SegVal),
+          proplists:get_value(
+              cuttlefish_variable:replace_match(Variable, SegVal), Conf)}
+         || {_, SegVal} <- Matches]);
+build_collect(Variable, Matches, {map, binary}, Conf) ->
+    maps:from_list(
+        [{list_to_binary(SegVal),
+          proplists:get_value(
+              cuttlefish_variable:replace_match(Variable, SegVal), Conf)}
+         || {_, SegVal} <- Matches]);
+build_collect(Variable, Matches, {proplist, atom}, Conf) ->
+    [{list_to_atom(SegVal),
+      proplists:get_value(
+          cuttlefish_variable:replace_match(Variable, SegVal), Conf)}
+     || {_, SegVal} <- lists:sort(Matches)].
 
 -spec apply_translations(cuttlefish_schema:schema(), cuttlefish_conf:conf(), [proplists:property()], [string()]) ->
                                 [proplists:property()] |
@@ -1762,6 +1827,141 @@ validate_unknown_variable_test() ->
     Conf = [{["unknown_key"], "42"}],
     Result = validate({[], Mappings, []}, Conf),
     ?assertMatch({error, {errorlist, [{error, {unknown_variable, _}}|_]}}, Result),
+    ok.
+
+%% collect tests
+
+collect_list_generator_test() ->
+    %% Mimics the listeners.tcp.$name → rabbit.tcp_listeners pattern.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
+            {datatype, integer},
+            {collect, list}
+        ]})
+    ],
+    %% Conf is post-datatype-conversion (typed values).
+    Conf = [
+        {["listeners", "tcp", "default"], 5672},
+        {["listeners", "tcp", "tls"],    5671}
+    ],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{tcp_listeners, _}]}], Result),
+    [{rabbit, [{tcp_listeners, Listeners}]}] = Result,
+    ?assertEqual([5671, 5672], lists:sort(Listeners)),
+    ok.
+
+collect_list_empty_generator_test() ->
+    %% When no conf values match the pattern, the key must be absent
+    %% from app.config (equivalent to cuttlefish:unset()).
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
+            {datatype, integer},
+            {collect, list}
+        ]})
+    ],
+    Conf = [],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertEqual([], Result),
+    ok.
+
+collect_list_sort_generator_test() ->
+    %% Values must be sorted lexicographically by the $name segment.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
+            {datatype, atom},
+            {collect, list}
+        ]})
+    ],
+    Conf = [
+        {["auth_mechanisms", "plain"],     plain},
+        {["auth_mechanisms", "amqplain"], amqplain},
+        {["auth_mechanisms", "external"], external}
+    ],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
+    [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
+    ?assertEqual([amqplain, external, plain], Mechanisms),
+    ok.
+
+collect_map_atom_generator_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "deprecated_features.permit.$name",
+                                  "rabbit.permit_deprecated_features", [
+            {datatype, {enum, [true, false]}},
+            {collect, {map, atom}}
+        ]})
+    ],
+    Conf = [
+        {["deprecated_features", "permit", "classic_queue_mirroring"], false},
+        {["deprecated_features", "permit", "transient_nonexcl_queues"],  true}
+    ],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{permit_deprecated_features, _}]}], Result),
+    [{rabbit, [{permit_deprecated_features, M}]}] = Result,
+    ?assert(is_map(M)),
+    ?assertEqual(false, maps:get(classic_queue_mirroring, M)),
+    ?assertEqual(true,  maps:get(transient_nonexcl_queues, M)),
+    ok.
+
+collect_map_binary_generator_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "tags.$name", "app.tags", [
+            {datatype, string},
+            {collect, {map, binary}}
+        ]})
+    ],
+    Conf = [
+        {["tags", "env"],  "production"},
+        {["tags", "team"], "platform"}
+    ],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertMatch([{app, [{tags, _}]}], Result),
+    [{app, [{tags, M}]}] = Result,
+    ?assert(is_map(M)),
+    ?assertEqual("production", maps:get(<<"env">>,  M)),
+    ?assertEqual("platform",   maps:get(<<"team">>, M)),
+    ok.
+
+collect_proplist_atom_generator_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "feature.$name", "app.features", [
+            {datatype, {enum, [true, false]}},
+            {collect, {proplist, atom}}
+        ]})
+    ],
+    Conf = [
+        {["feature", "alpha"], true},
+        {["feature", "beta"],  false}
+    ],
+    Result = map({[], Mappings, []}, Conf),
+    ?assertMatch([{app, [{features, _}]}], Result),
+    [{app, [{features, PL}]}] = Result,
+    ?assertEqual(true,  proplists:get_value(alpha, PL)),
+    ?assertEqual(false, proplists:get_value(beta,  PL)),
+    ok.
+
+collect_translation_takes_precedence_test() ->
+    %% When a translation exists for the same target, it must run and
+    %% the auto-collect must not fire.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
+            {datatype, integer},
+            {collect, list}
+        ]})
+    ],
+    Translations = [
+        cuttlefish_translation:parse({translation, "rabbit.tcp_listeners",
+            fun(Conf) ->
+                Settings = cuttlefish_variable:filter_by_prefix("listeners.tcp", Conf),
+                [V * 2 || {_, V} <- Settings]
+            end})
+    ],
+    Conf = [
+        {["listeners", "tcp", "default"], 5672}
+    ],
+    Result = map({Translations, Mappings, []}, Conf),
+    %% Translation doubles the port; if collect had run it would be [5672].
+    ?assertMatch([{rabbit, [{tcp_listeners, [11344]}]}], Result),
     ok.
 
 -endif.

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -188,7 +188,7 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
 %% to the mapping producing no output, like cuttlefish:unset()).
 -spec collect_fuzzy_values(
         cuttlefish_variable:variable(), string(),
-        cuttlefish_mapping:collect_type(),
+        cuttlefish_mapping:collection_type(),
         cuttlefish_conf:conf(),
         [proplists:property()], ordsets:ordset(string()), ordsets:ordset(string())) ->
     {[proplists:property()], {ordsets:ordset(string()), ordsets:ordset(string())}}.
@@ -212,7 +212,7 @@ collect_fuzzy_values(Variable, Mapping, CollectType, Conf, ConfAcc, MaybeDrop, K
 -spec build_collect(
         cuttlefish_variable:variable(),
         [{string(), string()}],
-        cuttlefish_mapping:collect_type(),
+        cuttlefish_mapping:collection_type(),
         cuttlefish_conf:conf()) -> term().
 build_collect(Variable, Matches, list, Conf) ->
     Entries = [{SegVal,

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -142,9 +142,7 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     %% if a user didn't actually configure this setting in the .conf file and
     %% there's no default in the schema, then there won't be enough information
     %% during the translation phase to succeed, so we'll earmark it to be skipped.
-    %% Fuzzy mappings with a {collect, Type} property and no translation are
-    %% auto-collected here: all conf values matching the wildcard pattern are
-    %% assembled into a list, map, or proplist and written to app.config directly.
+    %% If a fuzzy mapping has a collect property and no translation, its values are auto-collected.
     {DirectMappings, {TranslationsToMaybeDrop, TranslationsToKeep}} = lists:foldr(
         fun(MappingRecord, {ConfAcc, {MaybeDrop, Keep}}) ->
             Mapping = cuttlefish_mapping:mapping(MappingRecord),
@@ -182,10 +180,7 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     TranslationsToDrop = TranslationsToMaybeDrop -- TranslationsToKeep,
     {DirectMappings, TranslationsToDrop}.
 
-%% @doc Collects all conf values matching a fuzzy variable pattern and
-%% assembles them into the type specified by CollectType. Returns the
-%% accumulator unchanged when no conf values match the pattern (equivalent
-%% to the mapping producing no output, like cuttlefish:unset()).
+%% If there are no conf values matching the pattern, write an empty collection.
 -spec collect_fuzzy_values(
         cuttlefish_variable:variable(), string(),
         cuttlefish_mapping:collection_type(),
@@ -194,21 +189,13 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     {[proplists:property()], {ordsets:ordset(string()), ordsets:ordset(string())}}.
 collect_fuzzy_values(Variable, Mapping, CollectType, Conf, ConfAcc, MaybeDrop, Keep) ->
     Matches = cuttlefish_variable:fuzzy_matches(Variable, Conf),
-    case Matches of
-        [] ->
-            {ConfAcc, {ordsets:add_element(Mapping, MaybeDrop), Keep}};
-        _ ->
-            Tokens = cuttlefish_variable:tokenize(Mapping),
-            Value = build_collect(Variable, Matches, CollectType, Conf),
-            {set_value(Tokens, ConfAcc, Value),
-             {MaybeDrop, ordsets:add_element(Mapping, Keep)}}
-    end.
+    Tokens = cuttlefish_variable:tokenize(Mapping),
+    Value = build_collect(Variable, Matches, CollectType, Conf),
+    {set_value(Tokens, ConfAcc, Value),
+     {MaybeDrop, ordsets:add_element(Mapping, Keep)}}.
 
-%% @doc Assembles a collection value from the set of fuzzy-matched conf
-%% entries. Matches is the output of cuttlefish_variable:fuzzy_matches/2:
-%% a list of {WildcardSegment, ConcreteSegmentValue} pairs. Values are
-%% sorted lexicographically by the wildcard segment value for list and
-%% proplist output types.
+%% If multiple conf values match, assemble them into a collection, sorted by
+%% the wildcard segment value for list and proplist types.
 -spec build_collect(
         cuttlefish_variable:variable(),
         [{string(), string()}],
@@ -1832,14 +1819,12 @@ validate_unknown_variable_test() ->
 %% collect tests
 
 collect_list_generator_test() ->
-    %% Mimics the listeners.tcp.$name → rabbit.tcp_listeners pattern.
     Mappings = [
         cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
             {datatype, integer},
             {collect, list}
         ]})
     ],
-    %% Conf is post-datatype-conversion (typed values).
     Conf = [
         {["listeners", "tcp", "default"], 5672},
         {["listeners", "tcp", "tls"],    5671}
@@ -1851,8 +1836,7 @@ collect_list_generator_test() ->
     ok.
 
 collect_list_empty_generator_test() ->
-    %% When no conf values match the pattern, the key must be absent
-    %% from app.config (equivalent to cuttlefish:unset()).
+    %% If there are no matches, set the key with the value of [].
     Mappings = [
         cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
             {datatype, integer},
@@ -1861,11 +1845,11 @@ collect_list_empty_generator_test() ->
     ],
     Conf = [],
     Result = map({[], Mappings, []}, Conf),
-    ?assertEqual([], Result),
+    ?assertEqual([{rabbit, [{tcp_listeners, []}]}], Result),
     ok.
 
 collect_list_sort_generator_test() ->
-    %% Values must be sorted lexicographically by the $name segment.
+    %% Values are sorted by the $name segment.
     Mappings = [
         cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
             {datatype, atom},
@@ -1881,6 +1865,31 @@ collect_list_sort_generator_test() ->
     ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
     [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
     ?assertEqual([amqplain, external, plain], Mechanisms),
+    ok.
+
+collect_map_atom_empty_generator_test() ->
+    %% If there are no matches, set the key with the value of #{}.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "deprecated_features.permit.$name",
+                                  "rabbit.permit_deprecated_features", [
+            {datatype, {enum, [true, false]}},
+            {collect, {map, atom}}
+        ]})
+    ],
+    Result = map({[], Mappings, []}, []),
+    ?assertEqual([{rabbit, [{permit_deprecated_features, #{}}]}], Result),
+    ok.
+
+collect_map_binary_empty_generator_test() ->
+    %% If there are no matches, set the key with the value of #{}.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "tags.$name", "app.tags", [
+            {datatype, string},
+            {collect, {map, binary}}
+        ]})
+    ],
+    Result = map({[], Mappings, []}, []),
+    ?assertEqual([{app, [{tags, #{}}]}], Result),
     ok.
 
 collect_map_atom_generator_test() ->
@@ -1941,8 +1950,7 @@ collect_proplist_atom_generator_test() ->
     ok.
 
 collect_translation_takes_precedence_test() ->
-    %% When a translation exists for the same target, it must run and
-    %% the auto-collect must not fire.
+    %% If a translation and a collect mapping target the same key, the translation wins.
     Mappings = [
         cuttlefish_mapping:parse({mapping, "listeners.tcp.$name", "rabbit.tcp_listeners", [
             {datatype, integer},
@@ -1960,7 +1968,6 @@ collect_translation_takes_precedence_test() ->
         {["listeners", "tcp", "default"], 5672}
     ],
     Result = map({Translations, Mappings, []}, Conf),
-    %% Translation doubles the port; if collect had run it would be [5672].
     ?assertMatch([{rabbit, [{tcp_listeners, [11344]}]}], Result),
     ok.
 

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -382,12 +382,14 @@ remove_all_but_first(MappingName, Mappings) ->
         end, [], Mappings).
 
 -spec parse_collect(term()) -> collection_type() | undefined | cuttlefish_error:error().
-parse_collect(undefined)      -> undefined;
-parse_collect(list)           -> list;
-parse_collect({map, atom})    -> {map, atom};
-parse_collect({map, binary})  -> {map, binary};
+parse_collect(undefined)        -> undefined;
+parse_collect(list)             -> list;
+parse_collect({map, atom})      -> {map, atom};
+parse_collect({map, binary})    -> {map, binary};
 parse_collect({proplist, atom}) -> {proplist, atom};
-parse_collect(Other)          -> {error, {invalid_collect_type, Other}}.
+%% If {proplist, binary} is given, reject it; use {map, binary} for binary keys.
+parse_collect({proplist, binary}) -> {error, {unsupported_collect_type, {proplist, binary}}};
+parse_collect(Other)            -> {error, {invalid_collect_type, Other}}.
 
 -ifdef(TEST).
 
@@ -856,6 +858,12 @@ collect_invalid_type_test() ->
         {collect, not_valid}
     ]}),
     ?assertMatch({error, {invalid_collect_type, not_valid}}, Result).
+
+collect_proplist_binary_unsupported_test() ->
+    Result = parse({mapping, "prefix.$name", "app.key", [
+        {collect, {proplist, binary}}
+    ]}),
+    ?assertMatch({error, {unsupported_collect_type, {proplist, binary}}}, Result).
 
 collect_on_non_fuzzy_test() ->
     Result = parse({mapping, "no.wildcard", "app.key", [

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -25,7 +25,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--type collect_type() :: list
+-type collection_type() :: list
                       | {map, atom}
                       | {map, binary}
                       | {proplist, atom}.
@@ -45,12 +45,12 @@
         see = [] :: [cuttlefish_variable:variable()],
         hidden = false :: boolean(),
         aliases = [] :: [{cuttlefish_variable:variable(), string() | undefined}],
-        collect = undefined :: collect_type() | undefined
+        collect = undefined :: collection_type() | undefined
     }).
 
 -type mapping() :: #mapping{}.
 -type raw_mapping() :: {mapping, string(), string(), [proplists:property()]}.
--export_type([mapping/0, collect_type/0]).
+-export_type([mapping/0, collection_type/0]).
 
 -export([
     parse/1,
@@ -350,7 +350,7 @@ aliases(M) -> [Var || {Var, _Msg} <- M#mapping.aliases].
     [{cuttlefish_variable:variable(), string() | undefined}].
 aliases_with_messages(M) -> M#mapping.aliases.
 
--spec collect(mapping()) -> collect_type() | undefined.
+-spec collect(mapping()) -> collection_type() | undefined.
 collect(M) -> M#mapping.collect.
 
 -spec validators(mapping(), [cuttlefish_validator:validator()]) -> [cuttlefish_validator:validator()].
@@ -381,7 +381,7 @@ remove_all_but_first(MappingName, Mappings) ->
                 [M|Acc]
         end, [], Mappings).
 
--spec parse_collect(term()) -> collect_type() | undefined | cuttlefish_error:error().
+-spec parse_collect(term()) -> collection_type() | undefined | cuttlefish_error:error().
 parse_collect(undefined)      -> undefined;
 parse_collect(list)           -> list;
 parse_collect({map, atom})    -> {map, atom};

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -25,6 +25,11 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-type collect_type() :: list
+                      | {map, atom}
+                      | {map, binary}
+                      | {proplist, atom}.
+
 -record(mapping, {
         variable::cuttlefish_variable:variable(),
         mapping::string(),
@@ -39,12 +44,13 @@
         is_merge = false :: boolean(),
         see = [] :: [cuttlefish_variable:variable()],
         hidden = false :: boolean(),
-        aliases = [] :: [{cuttlefish_variable:variable(), string() | undefined}]
+        aliases = [] :: [{cuttlefish_variable:variable(), string() | undefined}],
+        collect = undefined :: collect_type() | undefined
     }).
 
 -type mapping() :: #mapping{}.
 -type raw_mapping() :: {mapping, string(), string(), [proplists:property()]}.
--export_type([mapping/0]).
+-export_type([mapping/0, collect_type/0]).
 
 -export([
     parse/1,
@@ -68,7 +74,8 @@
     validators/2,
     remove_all_but_first/2,
     aliases/1,
-    aliases_with_messages/1
+    aliases_with_messages/1,
+    collect/1
     ]).
 
 -spec parse(raw_mapping()) -> mapping() | cuttlefish_error:error().
@@ -94,28 +101,44 @@ parse({mapping, Variable, Mapping, Proplist}) ->
     VarTokenized = cuttlefish_variable:tokenize(Variable),
     IsMerge = proplists:is_defined(merge, Proplist),
     AliasesResult = parse_aliases(Variable, VarTokenized, Proplist, IsMerge),
+    CollectResult = parse_collect(proplists:get_value(collect, Proplist)),
 
-    case {Datatype, AliasesResult} of
-        {{error, _}, _} ->
+    case {Datatype, AliasesResult, CollectResult} of
+        {{error, _}, _, _} ->
             Datatype;
-        {_, {error, _} = AliasError} ->
+        {_, {error, _} = AliasError, _} ->
             AliasError;
-        {_, TokenizedAliases} ->
-            #mapping{
-                variable = VarTokenized,
-                default = proplists:get_value(default, Proplist),
-                commented = proplists:get_value(commented, Proplist),
-                mapping = Mapping,
-                level = proplists:get_value(level, Proplist, basic),
-                datatype = Datatype,
-                doc = proplists:get_value(doc, Proplist, []),
-                see = proplists:get_value(see, Proplist, []),
-                include_default = proplists:get_value(include_default, Proplist),
-                new_conf_value = proplists:get_value(new_conf_value, Proplist),
-                validators = proplists:get_value(validators, Proplist, []),
-                hidden = proplists:get_value(hidden, Proplist, false),
-                aliases = TokenizedAliases
-            }
+        {_, _, {error, _} = CollectError} ->
+            CollectError;
+        {_, TokenizedAliases, CollectType} ->
+            WildcardCount = length([S || S <- VarTokenized, hd(S) =:= $$]),
+            CollectError = case {CollectType, WildcardCount} of
+                {undefined, _}  -> ok;
+                {_, 0}          -> {error, {collect_on_non_fuzzy, Variable}};
+                {_, N} when N > 1 -> {error, {collect_multi_wildcard, Variable, N}};
+                {_, 1}          -> ok
+            end,
+            case CollectError of
+                {error, _} ->
+                    CollectError;
+                ok ->
+                    #mapping{
+                        variable = VarTokenized,
+                        default = proplists:get_value(default, Proplist),
+                        commented = proplists:get_value(commented, Proplist),
+                        mapping = Mapping,
+                        level = proplists:get_value(level, Proplist, basic),
+                        datatype = Datatype,
+                        doc = proplists:get_value(doc, Proplist, []),
+                        see = proplists:get_value(see, Proplist, []),
+                        include_default = proplists:get_value(include_default, Proplist),
+                        new_conf_value = proplists:get_value(new_conf_value, Proplist),
+                        validators = proplists:get_value(validators, Proplist, []),
+                        hidden = proplists:get_value(hidden, Proplist, false),
+                        aliases = TokenizedAliases,
+                        collect = CollectType
+                    }
+            end
     end;
 parse(X) ->
     {error, {mapping_parse, X}}.
@@ -248,7 +271,8 @@ merge(NewMappingSource, OldMapping) ->
                 validators = choose(validators, NewMappingSource, MergeMapping, OldMapping),
                 see = choose(see, NewMappingSource, MergeMapping, OldMapping),
                 hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping),
-                aliases = choose(aliases, NewMappingSource, MergeMapping, OldMapping)
+                aliases = choose(aliases, NewMappingSource, MergeMapping, OldMapping),
+                collect = choose(collect, NewMappingSource, MergeMapping, OldMapping)
             }
     end.
 
@@ -326,6 +350,9 @@ aliases(M) -> [Var || {Var, _Msg} <- M#mapping.aliases].
     [{cuttlefish_variable:variable(), string() | undefined}].
 aliases_with_messages(M) -> M#mapping.aliases.
 
+-spec collect(mapping()) -> collect_type() | undefined.
+collect(M) -> M#mapping.collect.
+
 -spec validators(mapping(), [cuttlefish_validator:validator()]) -> [cuttlefish_validator:validator()].
 validators(M, Validators) ->
     lists:foldr(fun(VName, Vs) ->
@@ -353,6 +380,14 @@ remove_all_but_first(MappingName, Mappings) ->
             (M, Acc) ->
                 [M|Acc]
         end, [], Mappings).
+
+-spec parse_collect(term()) -> collect_type() | undefined | cuttlefish_error:error().
+parse_collect(undefined)      -> undefined;
+parse_collect(list)           -> list;
+parse_collect({map, atom})    -> {map, atom};
+parse_collect({map, binary})  -> {map, binary};
+parse_collect({proplist, atom}) -> {proplist, atom};
+parse_collect(Other)          -> {error, {invalid_collect_type, Other}}.
 
 -ifdef(TEST).
 
@@ -785,6 +820,71 @@ aliases_tuple_not_string_error_test() ->
         {aliases, [{42, "msg"}]}
     ]}),
     ?assertMatch({error, {alias_not_a_string, "a.b", {42, "msg"}}}, Result).
+
+%% Collect parse tests
+
+collect_omitted_test() ->
+    M = parse({mapping, "prefix.$name", "app.key", [{datatype, integer}]}),
+    ?assertEqual(undefined, collect(M)).
+
+collect_list_test() ->
+    M = parse({mapping, "prefix.$name", "app.key", [
+        {datatype, integer}, {collect, list}
+    ]}),
+    ?assertEqual(list, collect(M)).
+
+collect_map_atom_test() ->
+    M = parse({mapping, "prefix.$name", "app.key", [
+        {collect, {map, atom}}
+    ]}),
+    ?assertEqual({map, atom}, collect(M)).
+
+collect_map_binary_test() ->
+    M = parse({mapping, "prefix.$name", "app.key", [
+        {collect, {map, binary}}
+    ]}),
+    ?assertEqual({map, binary}, collect(M)).
+
+collect_proplist_atom_test() ->
+    M = parse({mapping, "prefix.$name", "app.key", [
+        {collect, {proplist, atom}}
+    ]}),
+    ?assertEqual({proplist, atom}, collect(M)).
+
+collect_invalid_type_test() ->
+    Result = parse({mapping, "prefix.$name", "app.key", [
+        {collect, not_valid}
+    ]}),
+    ?assertMatch({error, {invalid_collect_type, not_valid}}, Result).
+
+collect_on_non_fuzzy_test() ->
+    Result = parse({mapping, "no.wildcard", "app.key", [
+        {collect, list}
+    ]}),
+    ?assertMatch({error, {collect_on_non_fuzzy, "no.wildcard"}}, Result).
+
+collect_multi_wildcard_test() ->
+    Result = parse({mapping, "a.$x.b.$y", "app.key", [
+        {collect, list}
+    ]}),
+    ?assertMatch({error, {collect_multi_wildcard, "a.$x.b.$y", 2}}, Result).
+
+collect_merge_inherits_test() ->
+    OldM = parse({mapping, "p.$n", "app.x", [
+        {default, 1}, {datatype, integer}, {collect, list}
+    ]}),
+    NewRaw = {mapping, "p.$n", "app.x", [merge, {default, 2}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual(list, collect(Merged)),
+    ?assertEqual(2, default(Merged)).
+
+collect_merge_replaces_test() ->
+    OldM = parse({mapping, "p.$n", "app.x", [
+        {default, 1}, {datatype, integer}, {collect, list}
+    ]}),
+    NewRaw = {mapping, "p.$n", "app.x", [merge, {collect, {map, atom}}]},
+    [Merged] = parse_and_merge(NewRaw, [OldM]),
+    ?assertEqual({map, atom}, collect(Merged)).
 
 aliases_merge_replaces_test() ->
     OldM = parse({mapping, "a.b", "app.x", [

--- a/test/cuttlefish_collect_integration_tests.erl
+++ b/test/cuttlefish_collect_integration_tests.erl
@@ -1,0 +1,272 @@
+%% -------------------------------------------------------------------
+%%
+%% Integration tests for the {collect, Type} mapping property.
+%%
+%% Each test pair demonstrates equivalence between the current RabbitMQ
+%% schema style (explicit translation) and the new {collect, Type} form.
+%% Schema patterns are taken verbatim from
+%% deps/rabbit/priv/schema/rabbit.schema in the rabbitmq-server repository.
+%%
+%% Copyright (c) 2024-2026 Broadcom Inc. or its subsidiaries. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_collect_integration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%
+%% Pattern 1: ssl_options.versions.$version → rabbit.ssl_options.versions
+%%
+%% From rabbit.schema lines 445-452. Collects all configured TLS version
+%% atoms into a plain list. The {collect, list} form is a drop-in replacement
+%% for the translation.
+%%
+
+%% Current form — explicit translation, exactly as in rabbit.schema.
+ssl_versions_current_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
+                                  "rabbit.ssl_options.versions",
+                                  [{datatype, atom}]})
+    ],
+    Translations = [
+        cuttlefish_translation:parse(
+            {translation, "rabbit.ssl_options.versions",
+             fun(Conf) ->
+                 Settings = cuttlefish_variable:filter_by_prefix(
+                              "ssl_options.versions", Conf),
+                 [V || {_, V} <- Settings]
+             end})
+    ],
+    Conf = [
+        {["ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+        {["ssl_options", "versions", "tlsv1.2"], 'tlsv1.2'}
+    ],
+    Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{ssl_options, [{versions, _}]}]}], Result),
+    [{rabbit, [{ssl_options, [{versions, Versions}]}]}] = Result,
+    ?assertEqual(['tlsv1.2', 'tlsv1.3'], lists:sort(Versions)),
+    ok.
+
+%% New form — {collect, list} replaces the translation entirely.
+ssl_versions_collect_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
+                                  "rabbit.ssl_options.versions",
+                                  [{datatype, atom}, {collect, list}]})
+    ],
+    Conf = [
+        {["ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+        {["ssl_options", "versions", "tlsv1.2"], 'tlsv1.2'}
+    ],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{ssl_options, [{versions, _}]}]}], Result),
+    [{rabbit, [{ssl_options, [{versions, Versions}]}]}] = Result,
+    %% {collect, list} sorts by the $version segment ("tlsv1.2" < "tlsv1.3").
+    ?assertEqual(['tlsv1.2', 'tlsv1.3'], Versions),
+    ok.
+
+%% Absent conf → key must not appear in app.config (both forms agree).
+ssl_versions_absent_current_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
+                                  "rabbit.ssl_options.versions",
+                                  [{datatype, atom}]})
+    ],
+    Translations = [
+        cuttlefish_translation:parse(
+            {translation, "rabbit.ssl_options.versions",
+             fun(Conf) ->
+                 Settings = cuttlefish_variable:filter_by_prefix(
+                              "ssl_options.versions", Conf),
+                 [V || {_, V} <- Settings]
+             end})
+    ],
+    Conf = [],
+    Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
+    %% Translation returns [] which cuttlefish treats as a valid empty list.
+    rabbit_ssl_versions_absent_assert(Result).
+
+ssl_versions_absent_collect_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
+                                  "rabbit.ssl_options.versions",
+                                  [{datatype, atom}, {collect, list}]})
+    ],
+    Conf = [],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    %% {collect, list} with no matches → key absent from app.config.
+    ?assertEqual([], Result),
+    ok.
+
+rabbit_ssl_versions_absent_assert(Result) ->
+    case Result of
+        [] -> ok;
+        [{rabbit, Opts}] ->
+            case proplists:get_value(ssl_options, Opts) of
+                undefined -> ok;
+                SslOpts ->
+                    case proplists:get_value(versions, SslOpts) of
+                        undefined -> ok;
+                        []        -> ok;
+                        Other     -> error({unexpected_versions, Other})
+                    end
+            end
+    end.
+
+%%
+%% Pattern 2: auth_mechanisms.$name → rabbit.auth_mechanisms
+%%
+%% From rabbit.schema lines 484-492. Collects SASL mechanism atoms into a
+%% sorted list. The translation uses lists:keysort/2; {collect, list} sorts
+%% by the $name segment, which is the last component — identical ordering.
+%%
+
+%% Current form — explicit translation, exactly as in rabbit.schema.
+auth_mechanisms_current_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
+                                  "rabbit.auth_mechanisms",
+                                  [{datatype, atom}]})
+    ],
+    Translations = [
+        cuttlefish_translation:parse(
+            {translation, "rabbit.auth_mechanisms",
+             fun(Conf) ->
+                 Settings = cuttlefish_variable:filter_by_prefix(
+                              "auth_mechanisms", Conf),
+                 Sorted = lists:keysort(1, Settings),
+                 [V || {_, V} <- Sorted]
+             end})
+    ],
+    Conf = [
+        {["auth_mechanisms", "PLAIN"],     'PLAIN'},
+        {["auth_mechanisms", "AMQPLAIN"], 'AMQPLAIN'}
+    ],
+    Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
+    [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
+    %% keysort on ["auth_mechanisms","AMQPLAIN"] vs ["auth_mechanisms","PLAIN"]:
+    %% "AMQPLAIN" < "PLAIN" lexicographically.
+    ?assertEqual(['AMQPLAIN', 'PLAIN'], Mechanisms),
+    ok.
+
+%% New form — {collect, list} produces identical sorted output.
+auth_mechanisms_collect_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
+                                  "rabbit.auth_mechanisms",
+                                  [{datatype, atom}, {collect, list}]})
+    ],
+    Conf = [
+        {["auth_mechanisms", "PLAIN"],     'PLAIN'},
+        {["auth_mechanisms", "AMQPLAIN"], 'AMQPLAIN'}
+    ],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
+    [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
+    %% {collect, list} sorts by $name segment: "AMQPLAIN" < "PLAIN".
+    ?assertEqual(['AMQPLAIN', 'PLAIN'], Mechanisms),
+    ok.
+
+%%
+%% Pattern 3: deprecated_features.permit.$name → rabbit.permit_deprecated_features
+%%
+%% From rabbit.schema lines 2325-2343. Collects feature flag enable/disable
+%% settings into a map keyed by atom. The current translation builds a map
+%% using maps:from_list/1; {collect, {map, atom}} does the same automatically.
+%%
+
+%% Current form — explicit translation, exactly as in rabbit.schema.
+deprecated_features_current_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse(
+            {mapping, "deprecated_features.permit.$name",
+             "rabbit.permit_deprecated_features",
+             [{datatype, {enum, [true, false]}}]})
+    ],
+    Translations = [
+        cuttlefish_translation:parse(
+            {translation, "rabbit.permit_deprecated_features",
+             fun(Conf) ->
+                 Settings = cuttlefish_variable:filter_by_prefix(
+                              "deprecated_features.permit", Conf),
+                 maps:from_list(
+                   [{list_to_atom(FeatureName), State}
+                    || {["deprecated_features", "permit", FeatureName], State}
+                       <- Settings])
+             end})
+    ],
+    Conf = [
+        {["deprecated_features", "permit", "classic_queue_mirroring"], false},
+        {["deprecated_features", "permit", "transient_nonexcl_queues"], true}
+    ],
+    Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{permit_deprecated_features, _}]}], Result),
+    [{rabbit, [{permit_deprecated_features, M}]}] = Result,
+    ?assert(is_map(M)),
+    ?assertEqual(false, maps:get(classic_queue_mirroring, M)),
+    ?assertEqual(true,  maps:get(transient_nonexcl_queues, M)),
+    ok.
+
+%% New form — {collect, {map, atom}} replaces the translation entirely.
+deprecated_features_collect_form_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse(
+            {mapping, "deprecated_features.permit.$name",
+             "rabbit.permit_deprecated_features",
+             [{datatype, {enum, [true, false]}}, {collect, {map, atom}}]})
+    ],
+    Conf = [
+        {["deprecated_features", "permit", "classic_queue_mirroring"], false},
+        {["deprecated_features", "permit", "transient_nonexcl_queues"], true}
+    ],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{permit_deprecated_features, _}]}], Result),
+    [{rabbit, [{permit_deprecated_features, M}]}] = Result,
+    ?assert(is_map(M)),
+    ?assertEqual(false, maps:get(classic_queue_mirroring, M)),
+    ?assertEqual(true,  maps:get(transient_nonexcl_queues, M)),
+    ok.
+
+%%
+%% Backwards-compatibility: existing schemas with translations are unaffected
+%% when the mapping has no {collect, ...} property. The translation always
+%% takes precedence when both a translation and a collect mapping exist for
+%% the same Erlang target.
+%%
+
+translation_always_takes_precedence_test() ->
+    %% Mapping declares {collect, list}, but a translation for the same
+    %% Erlang target also exists. The translation must win.
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
+                                  "rabbit.auth_mechanisms",
+                                  [{datatype, atom}, {collect, list}]})
+    ],
+    %% Translation returns a hard-coded sentinel to make detection easy.
+    Translations = [
+        cuttlefish_translation:parse(
+            {translation, "rabbit.auth_mechanisms",
+             fun(_Conf) -> [sentinel_value] end})
+    ],
+    Conf = [
+        {["auth_mechanisms", "PLAIN"], 'PLAIN'}
+    ],
+    Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
+    ?assertMatch([{rabbit, [{auth_mechanisms, [sentinel_value]}]}], Result),
+    ok.

--- a/test/cuttlefish_collect_integration_tests.erl
+++ b/test/cuttlefish_collect_integration_tests.erl
@@ -2,11 +2,6 @@
 %%
 %% Integration tests for the {collect, Type} mapping property.
 %%
-%% Each test pair demonstrates equivalence between the current RabbitMQ
-%% schema style (explicit translation) and the new {collect, Type} form.
-%% Schema patterns are taken verbatim from
-%% deps/rabbit/priv/schema/rabbit.schema in the rabbitmq-server repository.
-%%
 %% Copyright (c) 2024-2026 Broadcom Inc. or its subsidiaries. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
@@ -31,12 +26,8 @@
 %%
 %% Pattern 1: ssl_options.versions.$version → rabbit.ssl_options.versions
 %%
-%% From rabbit.schema lines 445-452. Collects all configured TLS version
-%% atoms into a plain list. The {collect, list} form is a drop-in replacement
-%% for the translation.
-%%
 
-%% Current form — explicit translation, exactly as in rabbit.schema.
+%% Current form — explicit translation.
 ssl_versions_current_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
@@ -76,11 +67,10 @@ ssl_versions_collect_form_test() ->
     Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
     ?assertMatch([{rabbit, [{ssl_options, [{versions, _}]}]}], Result),
     [{rabbit, [{ssl_options, [{versions, Versions}]}]}] = Result,
-    %% {collect, list} sorts by the $version segment ("tlsv1.2" < "tlsv1.3").
     ?assertEqual(['tlsv1.2', 'tlsv1.3'], Versions),
     ok.
 
-%% Absent conf → key must not appear in app.config (both forms agree).
+%% If there are no conf values, the translation is dropped and the key is absent.
 ssl_versions_absent_current_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse({mapping, "ssl_options.versions.$version",
@@ -98,7 +88,6 @@ ssl_versions_absent_current_form_test() ->
     ],
     Conf = [],
     Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
-    %% Translation returns [] which cuttlefish treats as a valid empty list.
     rabbit_ssl_versions_absent_assert(Result).
 
 ssl_versions_absent_collect_form_test() ->
@@ -109,8 +98,8 @@ ssl_versions_absent_collect_form_test() ->
     ],
     Conf = [],
     Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
-    %% {collect, list} with no matches → key absent from app.config.
-    ?assertEqual([], Result),
+    %% If there are no matches, the key is present with an empty list value.
+    ?assertMatch([{rabbit, [{ssl_options, [{versions, []}]}]}], Result),
     ok.
 
 rabbit_ssl_versions_absent_assert(Result) ->
@@ -131,12 +120,8 @@ rabbit_ssl_versions_absent_assert(Result) ->
 %%
 %% Pattern 2: auth_mechanisms.$name → rabbit.auth_mechanisms
 %%
-%% From rabbit.schema lines 484-492. Collects SASL mechanism atoms into a
-%% sorted list. The translation uses lists:keysort/2; {collect, list} sorts
-%% by the $name segment, which is the last component — identical ordering.
-%%
 
-%% Current form — explicit translation, exactly as in rabbit.schema.
+%% Current form — explicit translation.
 auth_mechanisms_current_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
@@ -160,12 +145,10 @@ auth_mechanisms_current_form_test() ->
     Result = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
     ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
     [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
-    %% keysort on ["auth_mechanisms","AMQPLAIN"] vs ["auth_mechanisms","PLAIN"]:
-    %% "AMQPLAIN" < "PLAIN" lexicographically.
     ?assertEqual(['AMQPLAIN', 'PLAIN'], Mechanisms),
     ok.
 
-%% New form — {collect, list} produces identical sorted output.
+%% New form — {collect, list}.
 auth_mechanisms_collect_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
@@ -179,19 +162,14 @@ auth_mechanisms_collect_form_test() ->
     Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
     ?assertMatch([{rabbit, [{auth_mechanisms, _}]}], Result),
     [{rabbit, [{auth_mechanisms, Mechanisms}]}] = Result,
-    %% {collect, list} sorts by $name segment: "AMQPLAIN" < "PLAIN".
     ?assertEqual(['AMQPLAIN', 'PLAIN'], Mechanisms),
     ok.
 
 %%
 %% Pattern 3: deprecated_features.permit.$name → rabbit.permit_deprecated_features
 %%
-%% From rabbit.schema lines 2325-2343. Collects feature flag enable/disable
-%% settings into a map keyed by atom. The current translation builds a map
-%% using maps:from_list/1; {collect, {map, atom}} does the same automatically.
-%%
 
-%% Current form — explicit translation, exactly as in rabbit.schema.
+%% Current form — explicit translation.
 deprecated_features_current_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse(
@@ -223,7 +201,7 @@ deprecated_features_current_form_test() ->
     ?assertEqual(true,  maps:get(transient_nonexcl_queues, M)),
     ok.
 
-%% New form — {collect, {map, atom}} replaces the translation entirely.
+%% New form — {collect, {map, atom}}.
 deprecated_features_collect_form_test() ->
     Mappings = [
         cuttlefish_mapping:parse(
@@ -244,21 +222,15 @@ deprecated_features_collect_form_test() ->
     ok.
 
 %%
-%% Backwards-compatibility: existing schemas with translations are unaffected
-%% when the mapping has no {collect, ...} property. The translation always
-%% takes precedence when both a translation and a collect mapping exist for
-%% the same Erlang target.
+%% If a translation and a collect mapping target the same key, the translation wins.
 %%
 
 translation_always_takes_precedence_test() ->
-    %% Mapping declares {collect, list}, but a translation for the same
-    %% Erlang target also exists. The translation must win.
     Mappings = [
         cuttlefish_mapping:parse({mapping, "auth_mechanisms.$name",
                                   "rabbit.auth_mechanisms",
                                   [{datatype, atom}, {collect, list}]})
     ],
-    %% Translation returns a hard-coded sentinel to make detection easy.
     Translations = [
         cuttlefish_translation:parse(
             {translation, "rabbit.auth_mechanisms",


### PR DESCRIPTION
A good frakking half of LoCs across RabbitMQ
schema files is taken by collection keys
that look like this:

```erl
{mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
    {datatype, atom}
]}.

{translation, "rabbit.auth_mechanisms",
fun(Conf) ->
    Settings = cuttlefish_variable:filter_by_prefix("auth_mechanisms", Conf),
    Sorted = lists:keysort(1, Settings),
    [V || {_, V} <- Sorted]
end}.
```

This is repetitive and also highly standardized,
so we can introduce a first class feature that would make the above snippets look like this:

```erl
{mapping, "auth_mechanisms.$name", "rabbit.auth_mechanisms", [
    {datatype, atom},
    {collect, list}
]}.
```

which is much harder to get wrong.

With this change, the keys with this `{collect, list}` tuple *and* fuzzy variables are treated specially
and instead of going over the standard translation, `collect_fuzzy_values/7` is used instead.

The following collection "types" are supported:

 * `list`
 * `{map, atom}` (keys are converted to atoms)
 * `{map, binary}` (keys are converted to binaries)
 * `{proplist, atom}`

`{proplist, binary}` is not a case used in RabbitMQ, so I figured it can be left out.

There is a good number of more complex collections in RabbitMQ that this feature cannot cover but it can remove some 30-40% of repetitive lines (and ≈ 20% in terms of keys) across our schemas, so it's already a win.

Note that integration tests literally borrow a few real world examples from RabbitMQ.