### PR TITLE
New data types: `regex` and `uri`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       LATEST_OTP_RELEASE: 28
     steps:
       - uses: actions/checkout@v5
+      # GitHub's windows-latest reports ImageOS=win25-vs2026 (same Windows
+      # Server 2025 base, different Visual Studio edition), which setup-beam
+      # does not yet map. Pin to the closest supported label.
+      # Remove once https://github.com/erlef/setup-beam/pull/461 ships.
+      - name: Set ImageOS for Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "ImageOS=win25" >> $GITHUB_ENV
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         id: install-erlang
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       LATEST_OTP_RELEASE: 28
     steps:
       - uses: actions/checkout@v5
-      - uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         id: install-erlang
         with:
           otp-version: ${{ matrix.otp_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Enhancements:**
+
+ - A new datatype, `uri`, `{uri, [Scheme]}`, validates that the value is a parseable URI with an allowed scheme and a non-empty host
+ - A new datatype, `regex`, validates that the value is a valid regular expression not prone to the most common excessive backtracking scenarios
+
 ## [v3.7.0](https://github.com/Kyorai/cuttlefish/tree/v3.7.0) (2026-05-11)
 
 [Full Changelog](https://github.com/Kyorai/cuttlefish/compare/v3.6.0...v3.7.0)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -332,6 +332,37 @@ plugins = plugin_a, plugin_b, plugin_c
 
 Pass the value through as a string. Semantically indicate that the value is a filesystem path. Erlang type: `string()`.
 
+### `regex`
+
+Validates that the value is a non-empty regular expression. The pattern is compiled at config-load time and probed for excessive backtracking. On success the input string is passed through unchanged. Erlang type: `string()`.
+
+```erlang
+{datatype, regex}
+```
+
+Backtracking detection uses PCRE's `match_limit` against short adversarial probes. It catches the common nested-quantifier and overlapping-alternation patterns — `(a+)+`, `(\w+)+`, `^([a-z]+)+$`, the classic "evil email" regex — that are still pathological in PCRE 8.x. Not covered:
+
+ - Nested quantifiers over rare characters (`(z+)+`); the probes do not begin with those characters
+ - Patterns that only blow up on inputs unlike the probes
+ - Patterns PCRE already short-circuits (`(a*)*`, `(.+)+`); these are accepted because they cannot run away on the consumer either
+
+Treat the datatype as a safety net against accidental pathological patterns in copy-pasted regexes, not as a defense against an adversarial author.
+
+### `uri` and `{uri, Schemes}`
+
+Validates that the value parses as a URI with a recognised scheme and a non-empty host. On success the input string is returned (trimmed of surrounding whitespace). Erlang type: `string()`.
+
+```erlang
+%% accepts both HTTP and HTTPS
+{datatype, uri}
+%% HTTPS only
+{datatype, {uri, [https]}}
+%% an explicitly provided scheme list
+{datatype, {uri, [amqp, amqps]}}
+```
+
+Bare `uri` is equivalent to `{uri, [http, https]}`. `Schemes` is a non-empty list of atoms; the scheme in the input is matched case-insensitively. Userinfo (`https://user:pass@host`), IPv6 literals (`https://[::1]:8080`), ports, paths, and query strings are all accepted. Reachability and DNS are not checked.
+
 ---
 
 ## Translations

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -43,6 +43,9 @@
                     {percent, float} |
                     float |
                     tagged_string |
+                    regex |
+                    uri |
+                    {uri, [atom()]} |
                     {list, datatype()}.
 -type extended() :: { integer, integer() } |
                     { string, string() } |
@@ -99,6 +102,10 @@ is_supported({percent, float}) -> true;
 is_supported(float) -> true;
 is_supported(tagged_string) -> true;
 is_supported(tagged_binary) -> true;
+is_supported(regex) -> true;
+is_supported(uri) -> true;
+is_supported({uri, Schemes}) when is_list(Schemes), Schemes =/= [] ->
+    lists:all(fun is_atom/1, Schemes);
 is_supported({list, {list, _}}) ->
     % lists of lists are not supported
     false;
@@ -203,6 +210,11 @@ to_string({Tag, String}, tagged_string) when is_list(Tag), is_list(String) -> Ta
 to_string({Tag, String}, tagged_binary) when is_list(Tag), is_list(String) -> Tag ++ ":" ++ String;
 to_string({Tag, Bin}, tagged_binary) when is_list(Tag), is_binary(Bin) -> Tag ++ ":" ++ binary_to_list(Bin);
 
+to_string(Regex, regex) when is_list(Regex) -> Regex;
+
+to_string(URI, uri) when is_list(URI) -> URI;
+to_string(URI, {uri, _}) when is_list(URI) -> URI;
+
 to_string(File, file) when is_list(File) -> File;
 
 to_string(Directory, directory) when is_list(Directory) -> Directory;
@@ -236,6 +248,21 @@ to_string(Value, MaybeExtendedDatatype) ->
     end.
 
 -define(TAGGED_VALUE_PREFIX_REGEX, <<"^[a-zA-Z0-9_]+\:">>).
+
+-define(DEFAULT_URI_SCHEMES, [http, https]).
+
+%% Match-step backtracking budget used when probing user patterns.
+-define(MATCH_STEP_BUDGET, 1000).
+
+%% Inputs used to probe user patterns for excessive backtracking.
+-define(REGEX_PROBES, [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "abababababababababababababababababababab!",
+    "1111111111111111111111111111111111111111!",
+    "abcdefghijklmnopqrstuvwxyz0123456789ABCD!",
+    "aaaa.aaaa.aaaa.aaaa.aaaaaaaaaaaaaaaaaaaa!"
+]).
 
 -spec from_string(term(), datatype()) -> term() | cuttlefish_error:error().
 from_string(Atom, atom) when is_atom(Atom) -> Atom;
@@ -315,6 +342,14 @@ from_string(Bytesize, bytesize) when is_integer(Bytesize) -> Bytesize;
 from_string(Bytesize, bytesize) when is_list(Bytesize) -> cuttlefish_bytesize:parse(Bytesize);
 
 from_string(String, string) when is_list(String) -> String;
+
+from_string(String, regex) when is_list(String) ->
+    validate_regex(String);
+
+from_string(String, uri) when is_list(String) ->
+    validate_uri(String, ?DEFAULT_URI_SCHEMES);
+from_string(String, {uri, Schemes}) when is_list(String), is_list(Schemes) ->
+    validate_uri(String, Schemes);
 
 from_string(File, file) when is_list(File) -> File;
 
@@ -448,6 +483,93 @@ from_string_to_uds(String, {UDSPlusColon, PortString}) ->
             uds_conversions(String, UDS, validate_uds(UDS));
         _OtherPort ->
             {error, {conversion, {String, 'UDS'}}}
+    end.
+
+validate_regex("") ->
+    {error, {regex_empty, ""}};
+validate_regex(String) when is_list(String) ->
+    case re:compile(String) of
+        {error, {Reason, Pos}} ->
+            {error, {regex_invalid_syntax, {String, Reason, Pos}}};
+        {ok, MP} ->
+            %% `report_errors' is required: without it, PCRE silently turns
+            %% a match_limit exhaustion into `nomatch'.
+            Opts = [{match_limit, ?MATCH_STEP_BUDGET},
+                    {match_limit_recursion, ?MATCH_STEP_BUDGET},
+                    report_errors],
+            case probe_backtracking(String, MP, Opts) of
+                ok    -> String;
+                over_budget -> {error, {regex_excessive_backtracking, String}}
+            end
+    end.
+
+probe_backtracking(String, MP, Opts) ->
+    case probe_all(MP, ?REGEX_PROBES, Opts) of
+        over_budget -> over_budget;
+        ok    -> probe_anchored(String, Opts)
+    end.
+
+probe_anchored(String, Opts) ->
+    case re:compile("^(?:" ++ String ++ ")$") of
+        %% Rare patterns (e.g. PCRE verbs that don't compose with grouping)
+        %% can fail to compile when wrapped. Fall back to the plain probe.
+        {error, _} ->
+            ok;
+        {ok, Anchored} ->
+            probe_all(Anchored, ?REGEX_PROBES, Opts)
+    end.
+
+probe_all(_MP, [], _Opts) -> ok;
+probe_all(MP, [Probe | Rest], Opts) ->
+    case re:run(Probe, MP, Opts) of
+        {error, match_limit}           -> over_budget;
+        {error, match_limit_recursion} -> over_budget;
+        _                              -> probe_all(MP, Rest, Opts)
+    end.
+
+validate_uri(String, Schemes) ->
+    case validate_uri_schemes(Schemes) of
+        ok    -> do_validate_uri(string:trim(String), Schemes);
+        Error -> Error
+    end.
+
+do_validate_uri("", _Schemes) ->
+    {error, {uri_empty, ""}};
+do_validate_uri(String, Schemes) ->
+    case uri_string:parse(String) of
+        {error, _Reason, _Term} ->
+            {error, {uri_malformed, String}};
+        Parsed when is_map(Parsed) ->
+            check_scheme_and_host(String, Parsed, Schemes)
+    end.
+
+check_scheme_and_host(String, Parsed, Schemes) ->
+    case maps:find(scheme, Parsed) of
+        error ->
+            {error, {uri_no_scheme, String}};
+        {ok, SchemeStr} ->
+            Lower = string:lowercase(SchemeStr),
+            Allowed = [atom_to_list(S) || S <- Schemes],
+            case lists:member(Lower, Allowed) of
+                false ->
+                    {error, {uri_bad_scheme, {String, Lower, Schemes}}};
+                true ->
+                    check_host(String, Parsed)
+            end
+    end.
+
+check_host(String, Parsed) ->
+    case maps:get(host, Parsed, "") of
+        "" -> {error, {uri_no_host, String}};
+        _  -> String
+    end.
+
+validate_uri_schemes([]) ->
+    {error, {uri_schemes_empty, []}};
+validate_uri_schemes(Schemes) when is_list(Schemes) ->
+    case lists:all(fun is_atom/1, Schemes) of
+        true -> ok;
+        _    -> {error, {uri_schemes_invalid, Schemes}}
     end.
 
 -ifdef(TEST).

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -185,7 +185,33 @@ xlate({collect_on_non_fuzzy, Variable}) ->
                   "in the variable name", [Variable]);
 xlate({collect_multi_wildcard, Variable, N}) ->
     io_lib:format("collect property on mapping ~ts has ~B wildcard segments; "
-                  "only a single wildcard is supported", [Variable, N]).
+                  "only a single wildcard is supported", [Variable, N]);
+xlate({regex_empty, _}) ->
+    "Regular expression cannot be empty";
+xlate({regex_invalid_syntax, {Value, Reason, Pos}}) ->
+    io_lib:format("~tp is not a valid regular expression (~ts at position ~B)",
+                  [Value, Reason, Pos]);
+xlate({regex_excessive_backtracking, Value}) ->
+    io_lib:format("~tp is prone to excessive backtracking; "
+                  "simplify the pattern or avoid nested or overlapping quantifiers",
+                  [Value]);
+xlate({uri_empty, _}) ->
+    "URI value cannot be empty";
+xlate({uri_malformed, Value}) ->
+    io_lib:format("~tp is not a parseable URI", [Value]);
+xlate({uri_no_scheme, Value}) ->
+    io_lib:format("URI ~tp is missing a scheme (e.g. https://)", [Value]);
+xlate({uri_no_host, Value}) ->
+    io_lib:format("URI ~tp is missing a host", [Value]);
+xlate({uri_bad_scheme, {Value, Got, Allowed}}) ->
+    AllowedList = string:join([atom_to_list(S) || S <- Allowed], ", "),
+    io_lib:format("URI ~tp uses scheme '~ts'; expected one of: ~ts",
+                  [Value, Got, AllowedList]);
+xlate({uri_schemes_empty, _}) ->
+    "URI scheme list cannot be empty";
+xlate({uri_schemes_invalid, Schemes}) ->
+    io_lib:format("URI schemes must be a non-empty list of atoms, got ~tp",
+                  [Schemes]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->

--- a/test/cuttlefish_regex_datatype_proper_tests.erl
+++ b/test/cuttlefish_regex_datatype_proper_tests.erl
@@ -1,0 +1,67 @@
+-module(cuttlefish_regex_datatype_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 300}, {to_file, user}]))).
+
+safe_patterns_accepted_test()      -> ?PROP(prop_safe_patterns_accepted()).
+output_equals_input_test()         -> ?PROP(prop_output_equals_input()).
+nested_quantifier_rejected_test()  -> ?PROP(prop_nested_quantifier_rejected()).
+idempotent_on_success_test()       -> ?PROP(prop_idempotent_on_success()).
+
+prop_safe_patterns_accepted() ->
+    ?FORALL(Pat, gen_safe_pattern(),
+        case cuttlefish_datatypes:from_string(Pat, regex) of
+            S when is_list(S) -> true;
+            _                 -> false
+        end).
+
+prop_output_equals_input() ->
+    ?FORALL(Pat, gen_safe_pattern(),
+        case cuttlefish_datatypes:from_string(Pat, regex) of
+            S when is_list(S) -> S =:= Pat;
+            _                 -> true
+        end).
+
+%% `.` is intentionally absent: it matches every probe character including the
+%% trailing failure byte, so the engine never has to backtrack.
+prop_nested_quantifier_rejected() ->
+    ?FORALL(Class, oneof(["[a-z]", "[a-zA-Z]", "[a-z0-9]", "\\w", "\\d"]),
+        begin
+            Pat = "^(" ++ Class ++ "+)+$",
+            case cuttlefish_datatypes:from_string(Pat, regex) of
+                {error, {regex_excessive_backtracking, _}} -> true;
+                _ -> false
+            end
+        end).
+
+prop_idempotent_on_success() ->
+    ?FORALL(Pat, gen_safe_pattern(),
+        case cuttlefish_datatypes:from_string(Pat, regex) of
+            S when is_list(S) ->
+                S =:= cuttlefish_datatypes:from_string(S, regex);
+            _ -> true
+        end).
+
+gen_safe_pattern() ->
+    ?LET(Parts, non_empty(list(gen_pattern_atom())),
+         maybe_anchor(lists:flatten(Parts))).
+
+gen_pattern_atom() ->
+    oneof([
+        gen_literal_char(),
+        gen_char_class(),
+        ?LET({C, Q}, {gen_literal_char(), oneof([$?, $+, $*])}, [C, Q]),
+        "\\."
+    ]).
+
+gen_literal_char() ->
+    oneof("abcdefghijklmnopqrstuvwxyz0123456789").
+
+gen_char_class() ->
+    oneof(["[a-z]", "[0-9]", "[a-zA-Z]", "[a-z0-9]", "\\w", "\\d", "\\s"]).
+
+maybe_anchor(Body) ->
+    ?LET({Start, End}, {oneof(["", "^"]), oneof(["", "$"])},
+         Start ++ Body ++ End).

--- a/test/cuttlefish_regex_datatype_tests.erl
+++ b/test/cuttlefish_regex_datatype_tests.erl
@@ -1,0 +1,96 @@
+-module(cuttlefish_regex_datatype_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+accepts_simple_anchored_test() ->
+    ?assertEqual("^[a-z]+$",
+                 cuttlefish_datatypes:from_string("^[a-z]+$", regex)).
+
+accepts_dot_star_test() ->
+    ?assertEqual(".*", cuttlefish_datatypes:from_string(".*", regex)).
+
+accepts_alternation_test() ->
+    ?assertEqual("^(foo|bar|baz)$",
+                 cuttlefish_datatypes:from_string("^(foo|bar|baz)$", regex)).
+
+accepts_word_class_test() ->
+    ?assertEqual("\\w+",
+                 cuttlefish_datatypes:from_string("\\w+", regex)).
+
+accepts_non_capturing_group_test() ->
+    ?assertEqual("(?:foo|bar)+",
+                 cuttlefish_datatypes:from_string("(?:foo|bar)+", regex)).
+
+accepts_atomic_group_test() ->
+    %% Atomic groups do not backtrack.
+    ?assertEqual("(?>a+)+b",
+                 cuttlefish_datatypes:from_string("(?>a+)+b", regex)).
+
+accepts_realistic_rabbitmq_pattern_test() ->
+    Pattern = "^[a-zA-Z0-9_\\-./]+$",
+    ?assertEqual(Pattern, cuttlefish_datatypes:from_string(Pattern, regex)).
+
+accepts_pattern_with_anchors_test() ->
+    ?assertEqual("^foo$",
+                 cuttlefish_datatypes:from_string("^foo$", regex)).
+
+rejects_empty_test() ->
+    ?assertMatch({error, {regex_empty, _}},
+                 cuttlefish_datatypes:from_string("", regex)).
+
+rejects_unbalanced_bracket_test() ->
+    ?assertMatch({error, {regex_invalid_syntax, _}},
+                 cuttlefish_datatypes:from_string("[unclosed", regex)).
+
+rejects_dangling_quantifier_test() ->
+    ?assertMatch({error, {regex_invalid_syntax, _}},
+                 cuttlefish_datatypes:from_string("*", regex)).
+
+rejects_nested_quantifiers_test() ->
+    ?assertMatch({error, {regex_excessive_backtracking, _}},
+                 cuttlefish_datatypes:from_string("(a+)+", regex)).
+
+rejects_anchored_nested_quantifiers_test() ->
+    ?assertMatch({error, {regex_excessive_backtracking, _}},
+                 cuttlefish_datatypes:from_string("^(a+)+$", regex)).
+
+rejects_overlapping_alternation_test() ->
+    ?assertMatch({error, {regex_excessive_backtracking, _}},
+                 cuttlefish_datatypes:from_string("^(a|a)*$", regex)).
+
+rejects_evil_email_test() ->
+    Pattern = "^([a-zA-Z0-9_.+-]+)+@([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$",
+    ?assertMatch({error, {regex_excessive_backtracking, _}},
+                 cuttlefish_datatypes:from_string(Pattern, regex)).
+
+accepts_pcre_safe_pattern_test() ->
+    %% PCRE 8.x detects the empty-match loop in (a*)*b and exits without
+    %% backtracking, so the validator must not flag it.
+    ?assertEqual("(a*)*b", cuttlefish_datatypes:from_string("(a*)*b", regex)).
+
+rejects_word_class_backtracking_test() ->
+    ?assertMatch({error, {regex_excessive_backtracking, _}},
+                 cuttlefish_datatypes:from_string("^(\\w+)+$", regex)).
+
+to_string_is_identity_test() ->
+    ?assertEqual("^[a-z]+$",
+                 cuttlefish_datatypes:to_string("^[a-z]+$", regex)).
+
+is_supported_test() ->
+    ?assert(cuttlefish_datatypes:is_supported(regex)),
+    ?assert(cuttlefish_datatypes:is_supported({list, regex})).
+
+error_messages_test() ->
+    Cases = [
+        {{regex_empty, ""},                                   "empty"},
+        {{regex_invalid_syntax, {"[abc", "missing terminating ]", 4}}, "valid"},
+        {{regex_excessive_backtracking, "(a+)+"},                              "backtracking"}
+    ],
+    lists:foreach(fun({Err, Substring}) ->
+        Msg = ?XLATE(Err),
+        ?assertNotEqual([], Msg),
+        ?assert(string:find(Msg, Substring) =/= nomatch,
+                io_lib:format("expected ~p in message ~p", [Substring, Msg]))
+    end, Cases).

--- a/test/cuttlefish_uri_datatype_proper_tests.erl
+++ b/test/cuttlefish_uri_datatype_proper_tests.erl
@@ -1,0 +1,83 @@
+-module(cuttlefish_uri_datatype_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 300}, {to_file, user}]))).
+
+http_or_https_accepted_test()    -> ?PROP(prop_http_or_https_accepted()).
+output_equals_trimmed_test()     -> ?PROP(prop_output_equals_trimmed()).
+unknown_scheme_rejected_test()   -> ?PROP(prop_unknown_scheme_rejected()).
+allowlist_filters_schemes_test() -> ?PROP(prop_allowlist_filters_schemes()).
+trim_idempotent_test()           -> ?PROP(prop_trim_idempotent()).
+
+prop_http_or_https_accepted() ->
+    ?FORALL(URI, gen_uri([http, https]),
+        is_list(cuttlefish_datatypes:from_string(URI, uri))).
+
+prop_output_equals_trimmed() ->
+    ?FORALL({Pre, Post, URI}, {gen_whitespace(), gen_whitespace(), gen_uri([http, https])},
+        begin
+            Padded = Pre ++ URI ++ Post,
+            cuttlefish_datatypes:from_string(Padded, uri) =:= URI
+        end).
+
+prop_unknown_scheme_rejected() ->
+    ?FORALL(URI, gen_uri([ftp]),
+        case cuttlefish_datatypes:from_string(URI, {uri, [http, https]}) of
+            {error, {uri_bad_scheme, _}} -> true;
+            _ -> false
+        end).
+
+prop_allowlist_filters_schemes() ->
+    ?FORALL({Allowed, AllowedURI, OtherURI}, gen_allowed_and_other(),
+        begin
+            AcceptedOK = is_list(cuttlefish_datatypes:from_string(
+                                   AllowedURI, {uri, [Allowed]})),
+            OtherRejected =
+                case cuttlefish_datatypes:from_string(
+                       OtherURI, {uri, [Allowed]}) of
+                    {error, {uri_bad_scheme, _}} -> true;
+                    _ -> false
+                end,
+            AcceptedOK andalso OtherRejected
+        end).
+
+gen_allowed_and_other() ->
+    ?LET({A, B}, ?SUCHTHAT({X, Y}, {gen_scheme(), gen_scheme()}, X =/= Y),
+         ?LET({UA, UB}, {gen_one_uri(A), gen_one_uri(B)}, {A, UA, UB})).
+
+prop_trim_idempotent() ->
+    ?FORALL(URI, gen_uri([http, https]),
+        begin
+            Once = cuttlefish_datatypes:from_string(URI, uri),
+            Twice = cuttlefish_datatypes:from_string(Once, uri),
+            Once =:= Twice
+        end).
+
+gen_uri(Schemes) ->
+    ?LET(S, oneof(Schemes), gen_one_uri(S)).
+
+gen_one_uri(Scheme) ->
+    ?LET({Host, MaybePort, MaybePath},
+         {gen_host(), gen_maybe_port(), gen_maybe_path()},
+         atom_to_list(Scheme) ++ "://" ++ Host ++ MaybePort ++ MaybePath).
+
+gen_scheme() -> oneof([http, https, ftp, amqp, amqps, ws, wss]).
+
+gen_host() ->
+    ?LET(Segments, non_empty(list(gen_label())),
+         string:join(Segments, ".")).
+
+gen_label() ->
+    ?LET(Chars, non_empty(list(oneof("abcdefghijklmnopqrstuvwxyz0123456789"))),
+         Chars).
+
+gen_maybe_port() ->
+    oneof(["", ":80", ":443", ":8080", ":65535"]).
+
+gen_maybe_path() ->
+    oneof(["", "/", "/foo", "/foo/bar", "/path?q=1", "/path#frag"]).
+
+gen_whitespace() ->
+    ?LET(N, integer(0, 4), string:copies(" ", N)).

--- a/test/cuttlefish_uri_datatype_tests.erl
+++ b/test/cuttlefish_uri_datatype_tests.erl
@@ -1,0 +1,162 @@
+-module(cuttlefish_uri_datatype_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+bare_uri_accepts_http_test() ->
+    ?assertEqual("http://example.com",
+                 cuttlefish_datatypes:from_string("http://example.com", uri)).
+
+bare_uri_accepts_https_test() ->
+    ?assertEqual("https://example.com",
+                 cuttlefish_datatypes:from_string("https://example.com", uri)).
+
+bare_uri_accepts_port_test() ->
+    ?assertEqual("https://example.com:8443",
+                 cuttlefish_datatypes:from_string("https://example.com:8443", uri)).
+
+bare_uri_accepts_path_test() ->
+    ?assertEqual("https://example.com/.well-known/jwks.json",
+                 cuttlefish_datatypes:from_string(
+                   "https://example.com/.well-known/jwks.json", uri)).
+
+bare_uri_accepts_query_string_test() ->
+    ?assertEqual("https://example.com/path?foo=1&bar=2",
+                 cuttlefish_datatypes:from_string(
+                   "https://example.com/path?foo=1&bar=2", uri)).
+
+bare_uri_accepts_fragment_test() ->
+    ?assertEqual("https://example.com/path#section",
+                 cuttlefish_datatypes:from_string(
+                   "https://example.com/path#section", uri)).
+
+bare_uri_accepts_trailing_slash_test() ->
+    ?assertEqual("https://example.com/",
+                 cuttlefish_datatypes:from_string("https://example.com/", uri)).
+
+bare_uri_accepts_userinfo_test() ->
+    ?assertEqual("https://user:pass@example.com",
+                 cuttlefish_datatypes:from_string(
+                   "https://user:pass@example.com", uri)).
+
+bare_uri_accepts_ipv4_host_test() ->
+    ?assertEqual("http://192.168.1.10:8080",
+                 cuttlefish_datatypes:from_string("http://192.168.1.10:8080", uri)).
+
+bare_uri_accepts_ipv6_host_test() ->
+    ?assertEqual("https://[::1]:8443",
+                 cuttlefish_datatypes:from_string("https://[::1]:8443", uri)).
+
+bare_uri_accepts_localhost_test() ->
+    ?assertEqual("http://localhost:5000",
+                 cuttlefish_datatypes:from_string("http://localhost:5000", uri)).
+
+bare_uri_preserves_uppercase_scheme_test() ->
+    ?assertEqual("HTTPS://example.com",
+                 cuttlefish_datatypes:from_string("HTTPS://example.com", uri)).
+
+bare_uri_trims_whitespace_test() ->
+    ?assertEqual("https://example.com",
+                 cuttlefish_datatypes:from_string("  https://example.com  ", uri)).
+
+reject_empty_test() ->
+    ?assertMatch({error, {uri_empty, _}},
+                 cuttlefish_datatypes:from_string("", uri)),
+    ?assertMatch({error, {uri_empty, _}},
+                 cuttlefish_datatypes:from_string("   ", uri)).
+
+reject_no_scheme_test() ->
+    ?assertMatch({error, {uri_no_scheme, _}},
+                 cuttlefish_datatypes:from_string("example.com/path", uri)).
+
+reject_no_host_test() ->
+    ?assertMatch({error, {uri_no_host, _}},
+                 cuttlefish_datatypes:from_string("https://", uri)),
+    ?assertMatch({error, {uri_no_host, _}},
+                 cuttlefish_datatypes:from_string("https:///foo", uri)).
+
+reject_wrong_scheme_test() ->
+    ?assertMatch({error, {uri_bad_scheme, _}},
+                 cuttlefish_datatypes:from_string("ftp://example.com", uri)),
+    ?assertMatch({error, {uri_bad_scheme, _}},
+                 cuttlefish_datatypes:from_string("file:///etc/passwd", uri)).
+
+reject_malformed_test() ->
+    ?assertMatch({error, {uri_malformed, _}},
+                 cuttlefish_datatypes:from_string("http://example.com:abc", uri)).
+
+reject_scheme_relative_test() ->
+    ?assertMatch({error, {uri_no_scheme, _}},
+                 cuttlefish_datatypes:from_string("//example.com/foo", uri)).
+
+reject_scheme_only_test() ->
+    ?assertMatch({error, {uri_no_host, _}},
+                 cuttlefish_datatypes:from_string("https:", uri)).
+
+reject_mixed_scheme_list_test() ->
+    ?assertMatch({error, {uri_schemes_invalid, _}},
+                 cuttlefish_datatypes:from_string("https://example.com",
+                                                  {uri, [http, "https"]})).
+
+https_only_accepts_https_test() ->
+    ?assertEqual("https://example.com",
+                 cuttlefish_datatypes:from_string("https://example.com",
+                                                  {uri, [https]})).
+
+https_only_rejects_http_test() ->
+    Result = cuttlefish_datatypes:from_string("http://example.com", {uri, [https]}),
+    ?assertMatch({error, {uri_bad_scheme, _}}, Result),
+    {error, Detail} = Result,
+    Msg = ?XLATE(Detail),
+    ?assert(string:find(Msg, "https") =/= nomatch).
+
+custom_schemes_amqp_test() ->
+    ?assertEqual("amqps://broker.local",
+                 cuttlefish_datatypes:from_string("amqps://broker.local",
+                                                  {uri, [amqp, amqps]})).
+
+empty_scheme_list_rejected_test() ->
+    ?assertMatch({error, {uri_schemes_empty, _}},
+                 cuttlefish_datatypes:from_string("https://example.com",
+                                                  {uri, []})).
+
+scheme_list_with_non_atom_rejected_test() ->
+    ?assertMatch({error, {uri_schemes_invalid, _}},
+                 cuttlefish_datatypes:from_string("https://example.com",
+                                                  {uri, ["https"]})).
+
+to_string_is_identity_test() ->
+    ?assertEqual("https://example.com",
+                 cuttlefish_datatypes:to_string("https://example.com", uri)),
+    ?assertEqual("https://example.com",
+                 cuttlefish_datatypes:to_string("https://example.com", {uri, [https]})).
+
+is_supported_test() ->
+    ?assert(cuttlefish_datatypes:is_supported(uri)),
+    ?assert(cuttlefish_datatypes:is_supported({uri, [https]})),
+    ?assert(cuttlefish_datatypes:is_supported({uri, [http, https]})),
+    ?assert(cuttlefish_datatypes:is_supported({uri, [amqp, amqps]})),
+    ?assertNot(cuttlefish_datatypes:is_supported({uri, []})),
+    ?assertNot(cuttlefish_datatypes:is_supported({uri, ["http"]})),
+    ?assertNot(cuttlefish_datatypes:is_supported({uri, foo})).
+
+list_of_uris_supported_test() ->
+    ?assert(cuttlefish_datatypes:is_supported({list, uri})),
+    ?assert(cuttlefish_datatypes:is_supported({list, {uri, [https]}})).
+
+error_messages_test() ->
+    Cases = [
+        {{uri_empty, ""},                      "URI value cannot be empty"},
+        {{uri_no_scheme, "example.com"},       "scheme"},
+        {{uri_no_host, "https://"},            "host"},
+        {{uri_malformed, "http://x:abc"},      "parseable"},
+        {{uri_schemes_empty, []},              "scheme list"},
+        {{uri_bad_scheme, {"ftp://x", "ftp", [http, https]}}, "expected one of"}
+    ],
+    lists:foreach(fun({Err, Substring}) ->
+        Msg = ?XLATE(Err),
+        ?assertNotEqual([], Msg),
+        ?assert(string:find(Msg, Substring) =/= nomatch,
+                io_lib:format("expected ~p in message ~p", [Substring, Msg]))
+    end, Cases).

--- a/test/cuttlefish_uri_regex_integration_tests.erl
+++ b/test/cuttlefish_uri_regex_integration_tests.erl
@@ -1,0 +1,68 @@
+-module(cuttlefish_uri_regex_integration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Exercises the uri and regex datatypes through the full generator pipeline.
+
+uri_mapping_accepts_https_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth.jwks_url",
+                                  "myapp.jwks_url",
+                                  [{datatype, {uri, [https]}}]})
+    ],
+    Conf = [{["auth", "jwks_url"], "https://identity.example.com/jwks"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertEqual([{myapp, [{jwks_url, "https://identity.example.com/jwks"}]}],
+                 Result).
+
+uri_mapping_rejects_http_when_only_https_allowed_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "auth.jwks_url",
+                                  "myapp.jwks_url",
+                                  [{datatype, {uri, [https]}}]})
+    ],
+    Conf = [{["auth", "jwks_url"], "http://identity.example.com/jwks"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertMatch({error, transform_datatypes, _}, Result).
+
+regex_mapping_accepts_safe_pattern_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "vhost.pattern",
+                                  "myapp.vhost_pattern",
+                                  [{datatype, regex}]})
+    ],
+    Conf = [{["vhost", "pattern"], "^[a-z0-9_-]+$"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertEqual([{myapp, [{vhost_pattern, "^[a-z0-9_-]+$"}]}], Result).
+
+regex_mapping_rejects_excessive_backtracking_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "vhost.pattern",
+                                  "myapp.vhost_pattern",
+                                  [{datatype, regex}]})
+    ],
+    Conf = [{["vhost", "pattern"], "^([a-z]+)+$"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertMatch({error, transform_datatypes, _}, Result).
+
+list_of_uris_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "endpoints",
+                                  "myapp.endpoints",
+                                  [{datatype, {list, uri}}]})
+    ],
+    Conf = [{["endpoints"], "https://a.example.com, http://b.example.com"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertEqual([{myapp, [{endpoints,
+                            ["https://a.example.com", "http://b.example.com"]}]}],
+                 Result).
+
+list_of_regexes_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse({mapping, "patterns",
+                                  "myapp.patterns",
+                                  [{datatype, {list, regex}}]})
+    ],
+    Conf = [{["patterns"], "^foo$, ^bar.*$"}],
+    Result = cuttlefish_generator:map({[], Mappings, []}, Conf),
+    ?assertEqual([{myapp, [{patterns, ["^foo$", "^bar.*$"]}]}], Result).


### PR DESCRIPTION
Several RabbitMQ schemas redeclare duplicate
validators for these types (HTTP, HTTPS endpoints, regular expressions).

`regex` checks that the value compiles and rejects patterns prone to excessive backtracking.

`uri`, `{uri, [Scheme]}` checks scheme membership
(case-insensitive) and hostname presence.
Bare `uri` is a shortcut for `{uri, [http, https]}`.

Neither transforms the value, therefore the existing translations do not need updating.