### PR TITLE
Improve validation of input schema files

### DIFF
--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -211,7 +211,23 @@ xlate({uri_schemes_empty, _}) ->
     "URI scheme list cannot be empty";
 xlate({uri_schemes_invalid, Schemes}) ->
     io_lib:format("URI schemes must be a non-empty list of atoms, got ~tp",
-                  [Schemes]).
+                  [Schemes]);
+xlate({schema_file, Filename, Inner}) ->
+    ["in schema file \"", Filename, "\": ", xlate(Inner)];
+xlate({not_a_schema_file, Filename}) ->
+    io_lib:format("refused to parse ~ts: not a schema file "
+                  "(expected a .schema extension)", [Filename]);
+xlate({schema_file_too_large, {Filename, Size, Limit}}) ->
+    io_lib:format("refused to parse ~ts: file size ~B bytes exceeds the "
+                  "schema size limit of ~B bytes", [Filename, Size, Limit]);
+xlate({schema_file_unrecognized_content, Filename}) ->
+    io_lib:format("refused to parse ~ts: content does not look like a "
+                  "cuttlefish schema (expected a top-level mapping, "
+                  "translation, or validator tuple)", [Filename]);
+xlate({schema_file_read_error, {Filename, Reason}}) ->
+    io_lib:format("could not read schema file ~ts: ~tp", [Filename, Reason]);
+xlate({schema_file_invalid_unicode, Filename}) ->
+    io_lib:format("schema file ~ts is not valid UTF-8", [Filename]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->
@@ -243,12 +259,11 @@ print(FormatString, Args) ->
 print({error, ErrorTerm}) ->
     print(lists:flatten(xlate(ErrorTerm)));
 print(String) ->
-    try
-        ?LOG_ERROR("~ts", [String])
-    catch _:_:_ ->
-        io:format("~ts~n", [String]),
-        ok
-    end.
+    %% A logger with no handler silently drops `?LOG_ERROR'; write
+    %% to `standard_error' too so misconfiguration is never silent.
+    io:format(standard_error, "~ts~n", [String]),
+    catch ?LOG_ERROR("~ts", [String]),
+    ok.
 
 -ifdef(TEST).
 
@@ -307,5 +322,78 @@ alias_error_xlate_test() ->
                  lists:flatten(xlate({alias_shadows_canonical, {"c.d", "a.b"}}))),
     ?assertEqual("Alias old.key is claimed by both a.b and c.d",
                  lists:flatten(xlate({alias_claimed_by_multiple_mappings, {"old.key", "a.b", "c.d"}}))).
+
+%% Schema-file error xlate tests for the tags introduced by the
+%% non-schema-file candidates.
+
+schema_file_wrap_xlate_test() ->
+    Inner = {error, {erl_scan, 32230}},
+    ?assertEqual(
+       "in schema file \"/tmp/erl_crash.dump\": "
+       "Error scanning erlang near line 32230",
+       lists:flatten(xlate({schema_file, "/tmp/erl_crash.dump", Inner}))),
+    ok.
+
+not_a_schema_file_xlate_test() ->
+    ?assertEqual(
+       "refused to parse /tmp/erl_crash.dump: not a schema file "
+       "(expected a .schema extension)",
+       lists:flatten(xlate({not_a_schema_file, "/tmp/erl_crash.dump"}))),
+    ok.
+
+schema_file_too_large_xlate_test() ->
+    ?assertEqual(
+       "refused to parse /tmp/big.schema: file size 16777216 bytes "
+       "exceeds the schema size limit of 8388608 bytes",
+       lists:flatten(xlate({schema_file_too_large,
+                            {"/tmp/big.schema", 16777216, 8388608}}))),
+    ok.
+
+schema_file_unrecognized_content_xlate_test() ->
+    ?assertEqual(
+       "refused to parse /tmp/foo.schema: content does not look like a "
+       "cuttlefish schema (expected a top-level mapping, translation, "
+       "or validator tuple)",
+       lists:flatten(xlate({schema_file_unrecognized_content, "/tmp/foo.schema"}))),
+    ok.
+
+schema_file_read_error_xlate_test() ->
+    ?assertEqual(
+       "could not read schema file /missing.schema: not_readable",
+       lists:flatten(xlate({schema_file_read_error,
+                            {"/missing.schema", not_readable}}))),
+    ok.
+
+schema_file_invalid_unicode_xlate_test() ->
+    ?assertEqual(
+       "schema file /tmp/garbage.schema is not valid UTF-8",
+       lists:flatten(xlate({schema_file_invalid_unicode, "/tmp/garbage.schema"}))),
+    ok.
+
+%% Re-register `standard_error' to a temp file so we can verify
+%% `print/1' reaches it without a logger handler.
+print_writes_to_standard_error_test() ->
+    StderrFile = filename:join(tmp_base(), "cuttlefish_print_stderr.txt"),
+    {ok, F} = file:open(StderrFile, [write]),
+    OldStderr = whereis(standard_error),
+    true = unregister(standard_error),
+    true = register(standard_error, F),
+    try
+        print("hello from stderr")
+    after
+        true = unregister(standard_error),
+        true = register(standard_error, OldStderr),
+        file:close(F)
+    end,
+    {ok, Bytes} = file:read_file(StderrFile),
+    file:delete(StderrFile),
+    ?assert(binary:match(Bytes, <<"hello from stderr">>) =/= nomatch),
+    ok.
+
+tmp_base() ->
+    case os:getenv("TMPDIR") of
+        false -> "/tmp";
+        T -> T
+    end.
 
 -endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -373,7 +373,8 @@ schema_file_invalid_unicode_xlate_test() ->
 %% Re-register `standard_error' to a temp file so we can verify
 %% `print/1' reaches it without a logger handler.
 print_writes_to_standard_error_test() ->
-    StderrFile = filename:join(tmp_base(), "cuttlefish_print_stderr.txt"),
+    StderrFile = filename:join(cuttlefish_paths:tmp_base(),
+                               "cuttlefish_print_stderr.txt"),
     {ok, F} = file:open(StderrFile, [write]),
     OldStderr = whereis(standard_error),
     true = unregister(standard_error),
@@ -389,11 +390,5 @@ print_writes_to_standard_error_test() ->
     file:delete(StderrFile),
     ?assert(binary:match(Bytes, <<"hello from stderr">>) =/= nomatch),
     ok.
-
-tmp_base() ->
-    case os:getenv("TMPDIR") of
-        false -> "/tmp";
-        T -> T
-    end.
 
 -endif.

--- a/src/cuttlefish_paths.erl
+++ b/src/cuttlefish_paths.erl
@@ -1,0 +1,85 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_paths: filesystem path helpers
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(cuttlefish_paths).
+
+-export([tmp_base/0]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-spec tmp_base() -> file:filename_all().
+tmp_base() ->
+    Candidates = [os:getenv("TMPDIR"),
+                  os:getenv("TEMP"),
+                  os:getenv("TMP")],
+    case [D || D <- Candidates, is_list(D), D =/= ""] of
+        [Dir | _] -> Dir;
+        []        -> "."
+    end.
+
+-ifdef(TEST).
+
+tmp_base_prefers_tmpdir_over_temp_and_tmp_test() ->
+    with_env([{"TMPDIR", "/from-tmpdir"},
+              {"TEMP",   "/from-temp"},
+              {"TMP",    "/from-tmp"}],
+             fun() -> ?assertEqual("/from-tmpdir", tmp_base()) end).
+
+tmp_base_falls_through_to_temp_then_tmp_test() ->
+    with_env([{"TMPDIR", false},
+              {"TEMP",   "/from-temp"},
+              {"TMP",    "/from-tmp"}],
+             fun() -> ?assertEqual("/from-temp", tmp_base()) end),
+    with_env([{"TMPDIR", false},
+              {"TEMP",   false},
+              {"TMP",    "/from-tmp"}],
+             fun() -> ?assertEqual("/from-tmp", tmp_base()) end).
+
+tmp_base_ignores_empty_env_vars_test() ->
+    with_env([{"TMPDIR", ""},
+              {"TEMP",   ""},
+              {"TMP",    "/real"}],
+             fun() -> ?assertEqual("/real", tmp_base()) end).
+
+tmp_base_falls_back_to_cwd_when_unset_test() ->
+    with_env([{"TMPDIR", false},
+              {"TEMP",   false},
+              {"TMP",    false}],
+             fun() -> ?assertEqual(".", tmp_base()) end).
+
+%% Snapshot the requested env vars, apply overrides, run `Body',
+%% then restore. `false' as a value means "unset for the duration".
+with_env(Overrides, Body) ->
+    Saved = [{Var, os:getenv(Var)} || {Var, _} <- Overrides],
+    try
+        lists:foreach(fun apply_env/1, Overrides),
+        Body()
+    after
+        lists:foreach(fun apply_env/1, Saved)
+    end.
+
+apply_env({Var, false}) -> os:unsetenv(Var);
+apply_env({Var, Val})   -> os:putenv(Var, Val).
+
+-endif.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -29,10 +29,13 @@
 -export([file/1]).
 -endif.
 
--export([files/1, strings/1]).
+-export([files/1, strings/1, list_schemas/1]).
 
 %% Exported for unit testing in other projects
 -export([merger/1, string_fun_factory/0]).
+
+%% Refuse schema files above 8 MiB.
+-define(MAX_SCHEMA_BYTES, 8388608).
 
 
 -type schema() :: {
@@ -58,34 +61,50 @@ merger(Fun, ListOfInputs) ->
                     schema() | cuttlefish_error:errorlist().
 merger(ListOfFunInputPairs) ->
     Schema = lists:foldr(
-        fun({Fun, Input}, {TranslationAcc, MappingAcc, ValidatorAcc}) ->
-            case Fun(Input, {TranslationAcc, MappingAcc, ValidatorAcc}) of
-                {errorlist, Errors} ->
-                    %% These have already been logged. We're not moving forward with this
-                    %% but, return them anyway so the rebar plugin can display them
-                    {errorlist, Errors};
-                {Translations, Mappings, Validators} ->
-                    NewMappings = lists:foldr(
-                        fun cuttlefish_mapping:replace/2,
-                        MappingAcc,
-                        Mappings),
+        fun
+            %% Propagate an errorlist accumulator instead of
+            %% crashing in the next iteration's 3-tuple match.
+            (_, {errorlist, _} = Errs) ->
+                Errs;
+            ({Fun, Input}, {TranslationAcc, MappingAcc, ValidatorAcc}) ->
+                case Fun(Input, {TranslationAcc, MappingAcc, ValidatorAcc}) of
+                    {errorlist, Errors} ->
+                        {errorlist, Errors};
+                    {Translations, Mappings, Validators} ->
+                        NewMappings = lists:foldr(
+                            fun cuttlefish_mapping:replace/2,
+                            MappingAcc,
+                            Mappings),
 
-                    NewTranslations = lists:foldr(
-                        fun cuttlefish_translation:replace/2,
-                        TranslationAcc,
-                        Translations),
+                        NewTranslations = lists:foldr(
+                            fun cuttlefish_translation:replace/2,
+                            TranslationAcc,
+                            Translations),
 
-                    NewValidators = lists:foldr(
-                        fun cuttlefish_validator:replace/2,
-                        ValidatorAcc,
-                        Validators),
+                        NewValidators = lists:foldr(
+                            fun cuttlefish_validator:replace/2,
+                            ValidatorAcc,
+                            Validators),
 
-                    {NewTranslations, NewMappings, NewValidators}
-            end
+                        {NewTranslations, NewMappings, NewValidators}
+                end
         end,
         {[], [], []},
         ListOfFunInputPairs),
     filter(Schema).
+
+%% @doc Sorted `*.schema' paths in `Dir', dotfiles excluded.
+-spec list_schemas(file:filename_all()) -> [file:filename_all()].
+list_schemas(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            [filename:join(Dir, F) ||
+                F <- lists:sort(Files),
+                lists:suffix(".schema", F),
+                not lists:prefix(".", F)];
+        {error, _} ->
+            []
+    end.
 
 %% This filter is *ONLY* for the case of multiple mappings to a single
 %% erlang app setting, *AND* there's no corresponding translation for
@@ -160,21 +179,105 @@ count_mappings(Mappings) ->
 
 -spec file(string(), schema()) -> schema() | cuttlefish_error:errorlist().
 file(Filename, Schema) ->
-    {ok, B, _} = erl_prim_loader:get_file(filename:absname(Filename)),
+    case is_schema_filename(Filename) of
+        false ->
+            wrap_errors(Filename, [{error, {not_a_schema_file, Filename}}]);
+        true ->
+            load_and_parse_schema_file(Filename, Schema)
+    end.
+
+%% Catches `.swp', `.DS_Store', crash dumps, and similar junk.
+-spec is_schema_filename(file:filename_all()) -> boolean().
+is_schema_filename(Filename) ->
+    filename:extension(Filename) =:= ".schema".
+
+load_and_parse_schema_file(Filename, Schema) ->
+    Abs = filename:absname(Filename),
+    case erl_prim_loader:get_file(Abs) of
+        {ok, B, _} ->
+            check_size_and_parse(Filename, B, Schema);
+        error ->
+            wrap_errors(Filename,
+                        [{error, {schema_file_read_error, {Filename, not_readable}}}])
+    end.
+
+check_size_and_parse(Filename, B, Schema) ->
+    case byte_size(B) of
+        Size when Size > ?MAX_SCHEMA_BYTES ->
+            wrap_errors(
+              Filename,
+              [{error, {schema_file_too_large,
+                        {Filename, Size, ?MAX_SCHEMA_BYTES}}}]);
+        _ ->
+            decode_and_parse(Filename, B, Schema)
+    end.
+
+decode_and_parse(Filename, B, Schema) ->
     case unicode:characters_to_list(B) of
-        {incomplete, _List, _RestBin}=Error ->
-            {error, Error};
-        {error, _List, _RestData}=Error ->
-            {error, Error};
-        Chardata when is_list(Chardata)->
+        {incomplete, _, _} ->
+            wrap_errors(Filename,
+                        [{error, {schema_file_invalid_unicode, Filename}}]);
+        {error, _, _} ->
+            wrap_errors(Filename,
+                        [{error, {schema_file_invalid_unicode, Filename}}]);
+        Chardata when is_list(Chardata) ->
+            sanity_check_and_parse(Filename, Chardata, Schema)
+    end.
+
+sanity_check_and_parse(Filename, Chardata, Schema) ->
+    case looks_like_schema(Chardata) of
+        false ->
+            wrap_errors(Filename,
+                        [{error, {schema_file_unrecognized_content, Filename}}]);
+        true ->
             case string(Chardata, Schema) of
                 {errorlist, Errors} ->
                     cuttlefish_error:print("Error parsing schema: ~ts", [Filename]),
-                    {errorlist, Errors};
+                    wrap_errors(Filename, Errors);
                 NewSchema ->
                     NewSchema
             end
     end.
+
+%% True if the first top-level term tag is `mapping', `translation',
+%% or `validator'. Whitespace-and-comments-only files also pass.
+-spec looks_like_schema(string()) -> boolean().
+looks_like_schema(Chardata) ->
+    case skip_whitespace_and_comments(Chardata) of
+        "" ->
+            true;
+        "{" ++ Rest ->
+            has_schema_tag(skip_whitespace_and_comments(Rest));
+        _ ->
+            false
+    end.
+
+has_schema_tag("mapping"     ++ _) -> true;
+has_schema_tag("translation" ++ _) -> true;
+has_schema_tag("validator"   ++ _) -> true;
+has_schema_tag(_) -> false.
+
+skip_whitespace_and_comments([C | T]) when C =:= $\s; C =:= $\t;
+                                           C =:= $\n; C =:= $\r ->
+    skip_whitespace_and_comments(T);
+skip_whitespace_and_comments([$% | T]) ->
+    skip_whitespace_and_comments(skip_to_newline(T));
+skip_whitespace_and_comments(Other) ->
+    Other.
+
+skip_to_newline([])        -> [];
+skip_to_newline([$\n | T]) -> T;
+skip_to_newline([_ | T])   -> skip_to_newline(T).
+
+%% Tag every error with its filename so callers can report which
+%% file failed without relying on a logger.
+-spec wrap_errors(file:filename_all(), [cuttlefish_error:error()]) ->
+    cuttlefish_error:errorlist().
+wrap_errors(Filename, Errors) ->
+    {errorlist, [wrap_error(Filename, E) || E <- Errors]}.
+
+wrap_error(Filename, {error, _} = Inner) ->
+    {error, {schema_file, Filename, Inner}}.
 
 %% @doc this exists so that we can create the fun using non exported
 %% functions for unit testing
@@ -321,6 +424,7 @@ percent_stripper_r(Line) ->
     lists:reverse(
         percent_stripper_l(
             lists:reverse(Line))).
+
 -ifdef(TEST).
 
 -define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
@@ -367,6 +471,8 @@ comment_parser_test() ->
     ok.
 
 bad_file_test() ->
+    %% The inner `erl_scan' error is preserved and wrapped with
+    %% the filename for caller-side reporting.
     _ = cuttlefish_test_logging:set_up(),
     _ = cuttlefish_test_logging:bounce(),
     {errorlist, ErrorList} = file("test/bad_erlang.schema"),
@@ -377,9 +483,10 @@ bad_file_test() ->
     ?assertMatch({match, _}, re:run(L1, "Error scanning erlang near line 10")),
     ?assertMatch({match, _}, re:run(L2, "Error parsing schema: test/bad_erlang.schema")),
 
-    ?assertEqual([
-        {error, {erl_scan, 10}}
-        ], ErrorList),
+    ?assertEqual(
+       [{error, {schema_file, "test/bad_erlang.schema",
+                 {error, {erl_scan, 10}}}}],
+       ErrorList),
     ok.
 
 parse_invalid_erlang_test() ->
@@ -604,5 +711,225 @@ alias_shadows_canonical_across_schema_strings_test() ->
     Schema2 = "{mapping, \"old.key\", \"e.j\", []}.\n",
     Result = strings([Schema1, Schema2]),
     ?assertMatch({errorlist, [{error, {alias_shadows_canonical, {"old.key", "a.b"}}}]}, Result).
+
+%% --- Tests for non-schema-file guards (Recommendations 1-3, 5). ---
+
+merger_does_not_crash_on_first_file_failure_test() ->
+    %% Previously this crashed with `function_clause' on the
+    %% iteration after the first errorlist accumulator.
+    BadFun = fun(_, _) -> {errorlist, [{error, {boom, "first"}}]} end,
+    OkFun = fun(_, {T, M, V}) -> {T, M, V} end,
+    Pairs = [{BadFun, "bad1"}, {OkFun, "good"}, {BadFun, "bad2"}],
+    Result = merger(Pairs),
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Errors} = Result,
+    ?assert(lists:any(
+              fun({error, {boom, _}}) -> true; (_) -> false end,
+              Errors)).
+
+merger_preserves_original_error_after_short_circuit_test() ->
+    BadFun = fun(_, _) -> {errorlist, [{error, {original, sentinel}}]} end,
+    OkFun = fun(_, {T, M, V}) -> {T, M, V} end,
+    Pairs = [{OkFun, "first_good"}, {BadFun, "the_bad_one"}, {OkFun, "last_good"}],
+    {errorlist, Errors} = merger(Pairs),
+    ?assertEqual([{error, {original, sentinel}}], Errors).
+
+merger_with_all_good_inputs_returns_schema_test() ->
+    OkFun = fun(_, {T, M, V}) -> {T, M, V} end,
+    ?assertEqual({[], [], []},
+                 merger([{OkFun, "a"}, {OkFun, "b"}])).
+
+not_a_schema_filename_is_refused_test() ->
+    Result = file("test/binary.schema.bad", {[], [], []}),
+    ?assertMatch({errorlist,
+                  [{error, {schema_file, "test/binary.schema.bad",
+                            {error, {not_a_schema_file, _}}}}]},
+                 Result).
+
+not_a_schema_filename_xlate_is_descriptive_test() ->
+    {errorlist, [{error, Wrapped}]} =
+        file("priv/schema/erl_crash.dump", {[], [], []}),
+    Msg = lists:flatten(cuttlefish_error:xlate(Wrapped)),
+    ?assert(string:find(Msg, "erl_crash.dump") =/= nomatch),
+    ?assert(string:find(Msg, "not a schema file") =/= nomatch),
+    ok.
+
+missing_schema_file_returns_descriptive_error_test() ->
+    Path = unique_tmp_path("missing-", ".schema"),
+    Result = file(Path, {[], [], []}),
+    ?assertMatch({errorlist,
+                  [{error, {schema_file, _,
+                            {error, {schema_file_read_error, {_, not_readable}}}}}]},
+                 Result).
+
+oversized_schema_file_is_refused_test() ->
+    Path = unique_tmp_path("oversize-", ".schema"),
+    Big = binary:copy(<<"x">>, 8388609),
+    ok = file:write_file(Path, Big),
+    try
+        Result = file(Path, {[], [], []}),
+        ?assertMatch(
+           {errorlist,
+            [{error, {schema_file, _,
+                      {error, {schema_file_too_large, {_, 8388609, 8388608}}}}}]},
+           Result)
+    after
+        file:delete(Path)
+    end.
+
+unrecognized_content_is_refused_test() ->
+    Path = unique_tmp_path("garbage-", ".schema"),
+    ok = file:write_file(Path, <<"=erl_crash_dump:0.5\nSomething: not schema\n">>),
+    try
+        Result = file(Path, {[], [], []}),
+        ?assertMatch(
+           {errorlist,
+            [{error, {schema_file, _,
+                      {error, {schema_file_unrecognized_content, _}}}}]},
+           Result)
+    after
+        file:delete(Path)
+    end.
+
+recognises_comments_before_first_tuple_test() ->
+    %% Schemas typically start with copyright comments.
+    Path = unique_tmp_path("commented-", ".schema"),
+    Bytes = <<"%% copyright header\n"
+              "%% more comments\n"
+              "{mapping, \"a.b\", \"app.k\", []}.\n">>,
+    ok = file:write_file(Path, Bytes),
+    try
+        ?assertMatch({_, [_], _}, file(Path, {[], [], []}))
+    after
+        file:delete(Path)
+    end.
+
+recognises_whitespace_between_brace_and_tag_test() ->
+    %% `test/riak.schema' uses `{ translation, ...}' (space after
+    %% the brace).
+    Path = unique_tmp_path("spaced-", ".schema"),
+    Bytes = <<"{\n  \tmapping, \"a.b\", \"app.k\", []}.\n">>,
+    ok = file:write_file(Path, Bytes),
+    try
+        ?assertMatch({_, [_], _}, file(Path, {[], [], []}))
+    after
+        file:delete(Path)
+    end.
+
+content_guard_rejects_non_schema_tuple_test() ->
+    %% A well-formed Erlang tuple with a non-schema tag is still
+    %% refused before reaching `erl_parse'.
+    Path = unique_tmp_path("wrong-tag-", ".schema"),
+    ok = file:write_file(Path, <<"{config, \"value\"}.\n">>),
+    try
+        ?assertMatch({errorlist,
+                      [{error, {schema_file, _,
+                                {error, {schema_file_unrecognized_content, _}}}}]},
+                     file(Path, {[], [], []}))
+    after
+        file:delete(Path)
+    end.
+
+empty_schema_file_is_accepted_test() ->
+    Path = unique_tmp_path("empty-", ".schema"),
+    ok = file:write_file(Path, <<"\n  %% just a comment\n\n">>),
+    try
+        ?assertEqual({[], [], []}, file(Path, {[], [], []}))
+    after
+        file:delete(Path)
+    end.
+
+invalid_unicode_in_schema_file_is_reported_test() ->
+    Path = unique_tmp_path("bad-unicode-", ".schema"),
+    %% Valid schema tuple followed by `0xFF' (never legal in UTF-8).
+    ok = file:write_file(Path, <<"{mapping, \"a\", \"b\", []}.", 16#FF>>),
+    try
+        Result = file(Path, {[], [], []}),
+        ?assertMatch({errorlist,
+                      [{error, {schema_file, _,
+                                {error, {schema_file_invalid_unicode, _}}}}]},
+                     Result)
+    after
+        file:delete(Path)
+    end.
+
+mixed_files_in_files_1_propagate_bad_filename_test() ->
+    Path = unique_tmp_path("bogus-", ".schema"),
+    ok = file:write_file(Path, <<"this is definitely not a schema file\n">>),
+    try
+        {errorlist, Errors} =
+            files(["test/multi1.schema", Path]),
+        ?assert(lists:any(
+                  fun({error, {schema_file, F, _}}) -> F =:= Path;
+                     (_) -> false
+                  end, Errors))
+    after
+        file:delete(Path)
+    end.
+
+list_schemas_returns_sorted_schema_files_only_test() ->
+    Dir = unique_tmp_dir("list-schemas-"),
+    ok = file:write_file(filename:join(Dir, "b.schema"), <<>>),
+    ok = file:write_file(filename:join(Dir, "a.schema"), <<>>),
+    ok = file:write_file(filename:join(Dir, "c.schema"), <<>>),
+    ok = file:write_file(filename:join(Dir, "README.md"), <<>>),
+    ok = file:write_file(filename:join(Dir, "erl_crash.dump"), <<>>),
+    ok = file:write_file(filename:join(Dir, ".hidden.schema"), <<>>),
+    ok = file:write_file(filename:join(Dir, "backup.schema~"), <<>>),
+    try
+        ?assertEqual([filename:join(Dir, "a.schema"),
+                      filename:join(Dir, "b.schema"),
+                      filename:join(Dir, "c.schema")],
+                     list_schemas(Dir))
+    after
+        cleanup_dir(Dir)
+    end.
+
+list_schemas_missing_dir_returns_empty_test() ->
+    Dir = unique_tmp_path("nonexistent-", ""),
+    ?assertEqual([], list_schemas(Dir)).
+
+list_schemas_empty_dir_returns_empty_test() ->
+    Dir = unique_tmp_dir("empty-list-"),
+    try
+        ?assertEqual([], list_schemas(Dir))
+    after
+        cleanup_dir(Dir)
+    end.
+
+list_schemas_ignores_editor_junk_test() ->
+    Dir = unique_tmp_dir("editor-junk-"),
+    ok = file:write_file(filename:join(Dir, "real.schema"), <<>>),
+    ok = file:write_file(filename:join(Dir, ".DS_Store"), <<>>),
+    ok = file:write_file(filename:join(Dir, ".real.schema.swp"), <<>>),
+    try
+        ?assertEqual([filename:join(Dir, "real.schema")], list_schemas(Dir))
+    after
+        cleanup_dir(Dir)
+    end.
+
+%% Unique temporary paths for the filesystem-touching guard tests.
+unique_tmp_dir(Prefix) ->
+    Path = unique_tmp_path(Prefix, ""),
+    ok = file:make_dir(Path),
+    Path.
+
+unique_tmp_path(Prefix, Suffix) ->
+    Base = case os:getenv("TMPDIR") of
+               false -> "/tmp";
+               T -> T
+           end,
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    filename:join(Base, Prefix ++ Unique ++ Suffix).
+
+cleanup_dir(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            lists:foreach(
+              fun(F) -> file:delete(filename:join(Dir, F)) end,
+              Files);
+        _ -> ok
+    end,
+    file:del_dir(Dir).
 
 -endif.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -915,12 +915,8 @@ unique_tmp_dir(Prefix) ->
     Path.
 
 unique_tmp_path(Prefix, Suffix) ->
-    Base = case os:getenv("TMPDIR") of
-               false -> "/tmp";
-               T -> T
-           end,
     Unique = integer_to_list(erlang:unique_integer([positive])),
-    filename:join(Base, Prefix ++ Unique ++ Suffix).
+    filename:join(cuttlefish_paths:tmp_base(), Prefix ++ Unique ++ Suffix).
 
 cleanup_dir(Dir) ->
     case file:list_dir(Dir) of

--- a/test/cuttlefish_schema_proper_tests.erl
+++ b/test/cuttlefish_schema_proper_tests.erl
@@ -1,0 +1,146 @@
+-module(cuttlefish_schema_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), {timeout, 60, ?_assert(proper:quickcheck(P, [{to_file, user}, {numtests, 200}]))}).
+
+list_schemas_only_returns_schema_extension_test_() ->
+    ?PROP(prop_list_schemas_only_schema_extension()).
+
+list_schemas_returns_sorted_test_() ->
+    ?PROP(prop_list_schemas_sorted()).
+
+list_schemas_ignores_dotfiles_test_() ->
+    ?PROP(prop_list_schemas_ignores_dotfiles()).
+
+file_refuses_non_schema_extensions_test_() ->
+    ?PROP(prop_non_schema_extension_refused()).
+
+%% --- Properties ---
+
+prop_list_schemas_only_schema_extension() ->
+    ?FORALL(Names, list(filename_gen()),
+            begin
+                Dir = make_dir_with(Names),
+                try
+                    All = cuttlefish_schema:list_schemas(Dir),
+                    lists:all(fun(P) ->
+                                      lists:suffix(".schema",
+                                                   filename:basename(P))
+                              end, All)
+                after
+                    cleanup_dir(Dir)
+                end
+            end).
+
+prop_list_schemas_sorted() ->
+    ?FORALL(Names, list(filename_gen()),
+            begin
+                Dir = make_dir_with(Names),
+                try
+                    Got = cuttlefish_schema:list_schemas(Dir),
+                    Got =:= lists:sort(Got)
+                after
+                    cleanup_dir(Dir)
+                end
+            end).
+
+prop_list_schemas_ignores_dotfiles() ->
+    ?FORALL(Names, list(filename_gen()),
+            begin
+                Dir = make_dir_with(Names),
+                try
+                    Got = cuttlefish_schema:list_schemas(Dir),
+                    lists:all(fun(P) ->
+                                      Base = filename:basename(P),
+                                      not lists:prefix(".", Base)
+                              end, Got)
+                after
+                    cleanup_dir(Dir)
+                end
+            end).
+
+prop_non_schema_extension_refused() ->
+    %% Any filename that does not end in `.schema' must surface as
+    %% `not_a_schema_file' without ever reaching `erl_scan'.
+    ?FORALL(Name, non_schema_filename_gen(),
+            begin
+                Result = cuttlefish_schema:files([Name]),
+                case Result of
+                    {errorlist, [{error, {schema_file, _,
+                                          {error, {not_a_schema_file, _}}}}]} ->
+                        true;
+                    _ ->
+                        false
+                end
+            end).
+
+%% --- Generators ---
+
+filename_gen() ->
+    %% A mixture of normal schema files, non-schema files, dotfiles,
+    %% and editor junk.
+    oneof([
+        ?LET(B, basename_chars(), B ++ ".schema"),
+        ?LET(B, basename_chars(), B ++ ".conf"),
+        ?LET(B, basename_chars(), B ++ ".md"),
+        ?LET(B, basename_chars(), "." ++ B),
+        ?LET(B, basename_chars(), "." ++ B ++ ".schema"),
+        ?LET(B, basename_chars(), B ++ ".schema~")
+    ]).
+
+non_schema_filename_gen() ->
+    oneof([
+        ?LET(B, basename_chars(), B ++ ".conf"),
+        ?LET(B, basename_chars(), B ++ ".dump"),
+        ?LET(B, basename_chars(), B ++ ".md"),
+        ?LET(B, basename_chars(), B ++ ".swp"),
+        ?LET(B, basename_chars(), B ++ "~"),
+        ?LET(B, basename_chars(), B)
+    ]).
+
+basename_chars() ->
+    %% Letters and digits only, length 1..10, to keep generated names
+    %% safe on every filesystem.
+    ?LET(L, integer(1, 10),
+         vector(L, oneof([integer($a, $z), integer($A, $Z), integer($0, $9)]))).
+
+%% --- Helpers ---
+
+make_dir_with(Names) ->
+    Dir = tmp_dir("schema-prop-"),
+    lists:foreach(
+      fun(N) ->
+              %% Skip ".", "..", and any name with a slash to keep mkfile safe.
+              case is_safe_name(N) of
+                  true ->
+                      _ = file:write_file(filename:join(Dir, N), <<"">>);
+                  false ->
+                      ok
+              end
+      end, Names),
+    Dir.
+
+is_safe_name(N) ->
+    N =/= "." andalso N =/= ".." andalso not lists:member($/, N).
+
+tmp_dir(Prefix) ->
+    Base = case os:getenv("TMPDIR") of
+               false -> "/tmp";
+               T -> T
+           end,
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    Dir = filename:join(Base, Prefix ++ Unique),
+    ok = file:make_dir(Dir),
+    Dir.
+
+cleanup_dir(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            lists:foreach(
+              fun(F) -> file:delete(filename:join(Dir, F)) end,
+              Files);
+        _ -> ok
+    end,
+    file:del_dir(Dir).

--- a/test/cuttlefish_schema_proper_tests.erl
+++ b/test/cuttlefish_schema_proper_tests.erl
@@ -126,12 +126,8 @@ is_safe_name(N) ->
     N =/= "." andalso N =/= ".." andalso not lists:member($/, N).
 
 tmp_dir(Prefix) ->
-    Base = case os:getenv("TMPDIR") of
-               false -> "/tmp";
-               T -> T
-           end,
     Unique = integer_to_list(erlang:unique_integer([positive])),
-    Dir = filename:join(Base, Prefix ++ Unique),
+    Dir = filename:join(cuttlefish_paths:tmp_base(), Prefix ++ Unique),
     ok = file:make_dir(Dir),
     Dir.
 


### PR DESCRIPTION
1. Make it easy to spot non-schema files amongst the inputs
2. Cap maximum schema file size at 8 MiB

As part of [1], we log the error to the standard error stream to make any non-compliant schema
files are easier to spot.
