### PR TITLE
New first class data type: booleans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,13 @@ Merges an `advanced.config` proplist on top of a generated config. Simple
 ### `cuttlefish_datatypes`
 
 String-to-typed-value conversion. Supports: `integer`, `string`, `atom`,
-`float`, `bytesize`, `duration`, `ip`, `fqdn`, `flag`, `{enum, [...]}`,
-`tagged_string`, `tagged_binary`, `{list, T}`, etc.
+`boolean`, `float`, `bytesize`, `duration`, `ip`, `fqdn`, `flag`,
+`{enum, [...]}`, `tagged_string`, `tagged_binary`, `{list, T}`, etc.
+
+`boolean` accepts the atoms `true` or `false` and the strings `"true"` or
+`"false"` (case-sensitive). It replaces `{enum, [true, false]}`, which is
+heavily duplicated across plugin schemas. Use `flag` for settings written
+as on/off in the conf file.
 
 `from_string/2` is the main entry point. Returns `{error, {conversion, ...}}`
 on failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Enhancements:**
 
+ - A new datatype, `boolean`, accepts the atoms `true` or `false` and the strings `"true"` or `"false"`. 
+   It seek to replace the very common `{enum, [true, false]}` pattern
  - A new datatype, `uri`, `{uri, [Scheme]}`, validates that the value is a parseable URI with an allowed scheme and a non-empty host
  - A new datatype, `regex`, validates that the value is a valid regular expression not prone to the most common excessive backtracking scenarios
 

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -28,6 +28,7 @@
 -type datatype() :: integer |
                     string |
                     atom |
+                    boolean |
                     file |
                     directory |
                     flag |
@@ -85,6 +86,7 @@ is_supported(flag) -> true;
 is_supported({flag, On, Off}) when is_atom(On), is_atom(Off) -> true;
 is_supported({flag, {On, _}, {Off, _}}) when is_atom(On), is_atom(Off) -> true;
 is_supported(atom) -> true;
+is_supported(boolean) -> true;
 is_supported({enum, E}) when is_list(E) -> true;
 is_supported(ip) -> true;
 is_supported(fqdn) -> true;
@@ -180,6 +182,11 @@ is_valid_list(List) ->
 to_string(Atom, atom) when is_list(Atom) -> Atom;
 to_string(Atom, atom) when is_atom(Atom) -> atom_to_list(Atom);
 
+to_string(true, boolean) -> "true";
+to_string(false, boolean) -> "false";
+to_string("true", boolean) -> "true";
+to_string("false", boolean) -> "false";
+
 to_string(Integer, integer) when is_integer(Integer) -> integer_to_list(Integer);
 to_string(Integer, integer) when is_list(Integer) -> Integer;
 
@@ -267,6 +274,13 @@ to_string(Value, MaybeExtendedDatatype) ->
 -spec from_string(term(), datatype()) -> term() | cuttlefish_error:error().
 from_string(Atom, atom) when is_atom(Atom) -> Atom;
 from_string(String, atom) when is_list(String) -> list_to_atom(String);
+
+from_string(true, boolean) -> true;
+from_string(false, boolean) -> false;
+from_string("true", boolean) -> true;
+from_string("false", boolean) -> false;
+from_string(Value, boolean) when is_list(Value); is_atom(Value) ->
+    {error, {conversion, {Value, boolean}}};
 
 from_string(String, binary) when is_list(String) -> list_to_binary(String);
 

--- a/test/cuttlefish_boolean_integration_tests.erl
+++ b/test/cuttlefish_boolean_integration_tests.erl
@@ -1,0 +1,47 @@
+-module(cuttlefish_boolean_integration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(SCHEMA, "{mapping, \"enable.thing\", \"myapp.enable_thing\", "
+                "[{datatype, boolean}, {default, true}]}.").
+
+default_is_applied_test() ->
+    Schema = cuttlefish_schema:strings([?SCHEMA]),
+    Conf = conf_parse:parse(<<>>),
+    Config = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual(true, lookup(Config, myapp, enable_thing)).
+
+override_with_false_test() ->
+    Schema = cuttlefish_schema:strings([?SCHEMA]),
+    Conf = conf_parse:parse(<<"enable.thing = false\n">>),
+    Config = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual(false, lookup(Config, myapp, enable_thing)).
+
+override_with_true_test() ->
+    Schema = cuttlefish_schema:strings([?SCHEMA]),
+    Conf = conf_parse:parse(<<"enable.thing = true\n">>),
+    Config = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual(true, lookup(Config, myapp, enable_thing)).
+
+%% Bad input bubbles out as a pipeline error rather than as a config value.
+invalid_value_fails_pipeline_test() ->
+    Schema = cuttlefish_schema:strings([?SCHEMA]),
+    Conf = conf_parse:parse(<<"enable.thing = yes\n">>),
+    ?assertMatch({error, transform_datatypes, _},
+                 cuttlefish_generator:map(Schema, Conf)).
+
+%% Translations run after the datatype pipeline, so a `boolean` mapping's
+%% translation sees the value as an Erlang `true`/`false` atom, not a string.
+translation_sees_typed_value_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"enable.thing\", \"myapp.enable_thing\", "
+            "[{datatype, boolean}, {default, false}]}.",
+        "{translation, \"myapp.enable_thing\", "
+            "fun(Conf) -> not cuttlefish:conf_get(\"enable.thing\", Conf) end}."
+    ]),
+    Conf = conf_parse:parse(<<"enable.thing = true\n">>),
+    Config = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual(false, lookup(Config, myapp, enable_thing)).
+
+lookup(Config, App, Key) ->
+    proplists:get_value(Key, proplists:get_value(App, Config)).

--- a/test/cuttlefish_boolean_proper_tests.erl
+++ b/test/cuttlefish_boolean_proper_tests.erl
@@ -1,0 +1,96 @@
+-module(cuttlefish_boolean_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 300}, {to_file, user}]))).
+
+canonical_atom_roundtrip_test()    -> ?PROP(prop_canonical_atom_roundtrip()).
+canonical_string_roundtrip_test()  -> ?PROP(prop_canonical_string_roundtrip()).
+to_string_yields_canonical_test()  -> ?PROP(prop_to_string_yields_canonical()).
+unknown_strings_rejected_test()    -> ?PROP(prop_unknown_strings_rejected()).
+unknown_atoms_rejected_test()      -> ?PROP(prop_unknown_atoms_rejected()).
+list_of_boolean_parses_test()      -> ?PROP(prop_list_of_boolean_parses()).
+atoms_are_fixed_points_test()      -> ?PROP(prop_atoms_are_fixed_points()).
+from_string_is_total_test()        -> ?PROP(prop_from_string_is_total()).
+
+%% Round-trip from an Erlang boolean: atom -> string -> atom.
+prop_canonical_atom_roundtrip() ->
+    ?FORALL(B, boolean(),
+        B =:= cuttlefish_datatypes:from_string(
+                cuttlefish_datatypes:to_string(B, boolean), boolean)).
+
+%% Round-trip from a canonical string: string -> atom -> string.
+prop_canonical_string_roundtrip() ->
+    ?FORALL(S, oneof(["true", "false"]),
+        S =:= cuttlefish_datatypes:to_string(
+                cuttlefish_datatypes:from_string(S, boolean), boolean)).
+
+%% `to_string/2` on any accepted input yields one of the canonical strings.
+prop_to_string_yields_canonical() ->
+    ?FORALL(V, accepted_value(),
+        lists:member(cuttlefish_datatypes:to_string(V, boolean),
+                     ["true", "false"])).
+
+%% Any string other than `"true"` or `"false"` is rejected with a
+%% `{conversion, ...}` error.
+prop_unknown_strings_rejected() ->
+    ?FORALL(S, non_canonical_string(),
+        case cuttlefish_datatypes:from_string(S, boolean) of
+            {error, {conversion, {S, boolean}}} -> true;
+            _                                   -> false
+        end).
+
+%% Any atom other than `true` or `false` is rejected; the error payload
+%% preserves the original atom for diagnostics.
+prop_unknown_atoms_rejected() ->
+    ?FORALL(A, non_canonical_atom(),
+        case cuttlefish_datatypes:from_string(A, boolean) of
+            {error, {conversion, {A, boolean}}} -> true;
+            _                                   -> false
+        end).
+
+%% A comma-separated list of canonical strings parses to the matching list
+%% of Erlang booleans.
+prop_list_of_boolean_parses() ->
+    ?FORALL(Bs, non_empty(list(boolean())),
+        begin
+            Strings = [atom_to_list(B) || B <- Bs],
+            Bs =:= cuttlefish_datatypes:from_string(
+                     string:join(Strings, ","), {list, boolean})
+        end).
+
+%% The atoms `true` and `false` are fixed points of `from_string/2`.
+prop_atoms_are_fixed_points() ->
+    ?FORALL(B, boolean(),
+        B =:= cuttlefish_datatypes:from_string(B, boolean)).
+
+%% `from_string/2` always returns either a boolean atom or a `{conversion, ...}` tuple.
+prop_from_string_is_total() ->
+    ?FORALL(X, oneof([true, false, "true", "false",
+                      non_canonical_string(), non_canonical_atom()]),
+        case cuttlefish_datatypes:from_string(X, boolean) of
+            true                          -> true;
+            false                         -> true;
+            {error, {conversion, {X, boolean}}} -> true;
+            _                             -> false
+        end).
+
+%%
+%% Generators
+%%
+
+accepted_value() ->
+    oneof([true, false, "true", "false"]).
+
+%% Lowercase, uppercase, digits and spaces. Uppercase coverage means the
+%% property also pins down case-sensitivity.
+non_canonical_string() ->
+    ?SUCHTHAT(S,
+              non_empty(list(oneof("abcdefghijklmnopqrstuvwxyz"
+                                   "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                   "0123456789 "))),
+              S =/= "true" andalso S =/= "false").
+
+non_canonical_atom() ->
+    ?LET(S, non_canonical_string(), list_to_atom(S)).

--- a/test/cuttlefish_boolean_tests.erl
+++ b/test/cuttlefish_boolean_tests.erl
@@ -1,0 +1,90 @@
+-module(cuttlefish_boolean_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FROM(V), cuttlefish_datatypes:from_string(V, boolean)).
+-define(TO(V),   cuttlefish_datatypes:to_string(V, boolean)).
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+is_supported_test() ->
+    ?assert(cuttlefish_datatypes:is_supported(boolean)),
+    ?assert(cuttlefish_datatypes:is_supported({list, boolean})).
+
+from_string_accepts_canonical_strings_test() ->
+    ?assertEqual(true,  ?FROM("true")),
+    ?assertEqual(false, ?FROM("false")).
+
+from_string_accepts_canonical_atoms_test() ->
+    ?assertEqual(true,  ?FROM(true)),
+    ?assertEqual(false, ?FROM(false)).
+
+from_string_is_case_sensitive_test() ->
+    ?assertMatch({error, {conversion, {"True",  boolean}}}, ?FROM("True")),
+    ?assertMatch({error, {conversion, {"TRUE",  boolean}}}, ?FROM("TRUE")),
+    ?assertMatch({error, {conversion, {"False", boolean}}}, ?FROM("False")).
+
+from_string_rejects_flag_words_test() ->
+    %% On/off/yes/no belong to `flag`, not `boolean`.
+    ?assertMatch({error, {conversion, {"yes", boolean}}}, ?FROM("yes")),
+    ?assertMatch({error, {conversion, {"no",  boolean}}}, ?FROM("no")),
+    ?assertMatch({error, {conversion, {"on",  boolean}}}, ?FROM("on")),
+    ?assertMatch({error, {conversion, {"off", boolean}}}, ?FROM("off")).
+
+from_string_rejects_empty_and_whitespace_test() ->
+    ?assertMatch({error, {conversion, {"",      boolean}}}, ?FROM("")),
+    ?assertMatch({error, {conversion, {" true", boolean}}}, ?FROM(" true")),
+    ?assertMatch({error, {conversion, {"true ", boolean}}}, ?FROM("true ")).
+
+from_string_rejects_unknown_string_test() ->
+    ?assertMatch({error, {conversion, {"perhaps", boolean}}}, ?FROM("perhaps")),
+    ?assertMatch({error, {conversion, {"1",       boolean}}}, ?FROM("1")),
+    ?assertMatch({error, {conversion, {"0",       boolean}}}, ?FROM("0")).
+
+from_string_rejects_unknown_atom_test() ->
+    ?assertMatch({error, {conversion, {perhaps, boolean}}}, ?FROM(perhaps)).
+
+from_string_non_string_non_atom_falls_through_test() ->
+    %% Wrong-shape input lands on the catch-all and reports `{type, ...}`.
+    ?assertMatch({error, {type, {42, boolean}}},     ?FROM(42)),
+    ?assertMatch({error, {type, {{a, b}, boolean}}}, ?FROM({a, b})).
+
+to_string_canonical_atoms_test() ->
+    ?assertEqual("true",  ?TO(true)),
+    ?assertEqual("false", ?TO(false)).
+
+to_string_canonical_strings_pass_through_test() ->
+    ?assertEqual("true",  ?TO("true")),
+    ?assertEqual("false", ?TO("false")).
+
+to_string_non_canonical_falls_through_test() ->
+    %% `to_string/2` has no clause for non-canonical input; it lands on the
+    %% catch-all and reports `{type, ...}`.
+    ?assertMatch({error, {type, {perhaps, boolean}}}, ?TO(perhaps)),
+    ?assertMatch({error, {type, {"perhaps", boolean}}}, ?TO("perhaps")).
+
+xlate_conversion_error_test() ->
+    %% Pin the rendered error so any regression in
+    %% `cuttlefish_error:xlate/1` fails visibly. `~tp` renders the string
+    %% form with quotes and the atom form without.
+    ?assertEqual("\"perhaps\" cannot be converted to a(n) boolean",
+                 ?XLATE(?FROM("perhaps"))),
+    ?assertEqual("perhaps cannot be converted to a(n) boolean",
+                 ?XLATE(?FROM(perhaps))).
+
+roundtrip_through_to_string_test() ->
+    %% `to_string/2` inverts `from_string/2` on canonical values.
+    ?assertEqual(true,  ?FROM(?TO(true))),
+    ?assertEqual(false, ?FROM(?TO(false))).
+
+list_of_boolean_test() ->
+    ?assertEqual([true, false, true, false],
+                 cuttlefish_datatypes:from_string("true, false, true, false",
+                                                  {list, boolean})).
+
+list_of_boolean_propagates_errors_test() ->
+    %% Elements convert independently; bad ones surface inline.
+    ?assertEqual([true,
+                  {error, {conversion, {"perhaps", boolean}}},
+                  false],
+                 cuttlefish_datatypes:from_string("true, perhaps, false",
+                                                  {list, boolean})).


### PR DESCRIPTION
RabbitMQ schema files have dozens of `{enum, [true, false]}` repetitions. Perhaps booleans deserve a first class data type.