### PR TITLE
Improve support for numerical data types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,34 @@ String-to-typed-value conversion. Supports: `integer`, `string`, `atom`,
 heavily duplicated across plugin schemas. Use `flag` for settings written
 as on/off in the conf file.
 
+Numerical types accept range constraints. `{integer, [Constraint, ...]}`
+and `{float, [Constraint, ...]}` check the constraints in declaration
+order; the first failure wins. A constraint is one of `{min, N}`,
+`{max, N}`, `{gt, N}`, `{lt, N}`, or the shortcut atoms `non_negative`
+(`{min, 0}`) and `positive` (`{min, 1}` for integers, `{gt, 0}` for
+floats). A bare shortcut may stand in for the list: `{integer,
+non_negative}`. Three aliases cover common ranges:
+
+- `port` = `{integer, [{min, 0}, {max, 65535}]}` (accepts the full IANA
+  range, including `0` for "OS-assigned" semantics)
+- `byte` = `{integer, [{min, 0}, {max, 255}]}`
+- `percent` = `{percent, integer}` (0-100)
+
+Out-of-range values surface as
+`{error, {range_violation, {Value, FailedConstraint}}}`.
+
+For settings that accept the atom `infinity` in addition to a numeric
+value (the historical `non_negative_integer` validator pattern in
+`rabbit.schema`), compose the new constrained type with the existing
+datatype-list mechanism — first match wins:
+
+```erlang
+{datatype, [{atom, infinity}, {integer, non_negative}]}
+```
+
 `from_string/2` is the main entry point. Returns `{error, {conversion, ...}}`
-on failure.
+on a parse failure and `{error, {range_violation, ...}}` on a constraint
+failure.
 
 ### `cuttlefish_variable`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 **Enhancements:**
 
- - A new datatype, `boolean`, accepts the atoms `true` or `false` and the strings `"true"` or `"false"`. 
-   It seek to replace the very common `{enum, [true, false]}` pattern
- - A new datatype, `uri`, `{uri, [Scheme]}`, validates that the value is a parseable URI with an allowed scheme and a non-empty host
- - A new datatype, `regex`, validates that the value is a valid regular expression not prone to the most common excessive backtracking scenarios
+ - New datatype `boolean`: accepts `true`/`false` (atom or string). Replaces the common `{enum, [true, false]}`
+ - New datatype `regex`: validates a regex and rejects patterns prone to excessive backtracking
+ - New datatype `uri` (and `{uri, [Scheme]}`): validates a parseable URI with an allowed scheme and a non-empty host
+ - Range constraints on `integer`: `{integer, [{min, N}, {max, N}, {gt, N}, {lt, N}]}`, plus shortcut atoms `non_negative` and `positive`
+ - Range constraints on `float`: `{float, [{min, N}, {max, N}, {gt, N}, {lt, N}]}`, plus shortcut atoms `non_negative` and `positive`
+ - New datatype alias `port` for `{integer, [{min, 0}, {max, 65535}]}`
+ - New datatype alias `byte` for `{integer, [{min, 0}, {max, 255}]}`
+ - New datatype alias `percent` for `{percent, integer}` (0-100)
 
 ## [v3.7.0](https://github.com/Kyorai/cuttlefish/tree/v3.7.0) (2026-05-11)
 

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -225,13 +225,20 @@ generate_comments(M) ->
 -spec pretty_datatype(cuttlefish_datatypes:datatype() |
                       cuttlefish_datatypes:extended()) -> string().
 pretty_datatype(integer) -> "an integer";
+pretty_datatype(port) -> "an integer in 0-65535 (TCP/UDP port)";
+pretty_datatype(byte) -> "an integer in 0-255";
+pretty_datatype(percent) -> "an integer percent in 0-100, with a trailing '%' on string input";
+pretty_datatype({integer, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    "an integer" ++ render_numeric_constraints(Constraints);
+pretty_datatype({float, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    "a float" ++ render_numeric_constraints(Constraints);
 pretty_datatype({enum, L}) ->
     "one of: " ++ string:join([ atom_to_list(A) || A <- L], ", ");
 pretty_datatype(ip) -> "an IP/port pair, e.g. 127.0.0.1:10011";
 pretty_datatype(domain_socket) -> "a Unix Domain Socket, e.g. local:/var/run/app.sock:0";
 pretty_datatype({duration, _}) -> "a time duration with units, e.g. '10s' for 10 seconds";
 pretty_datatype(bytesize) -> "a byte size with units, e.g. 10GB";
-pretty_datatype({integer, I}) -> "the integer " ++ integer_to_list(I);
+pretty_datatype({integer, I}) when is_integer(I) -> "the integer " ++ integer_to_list(I);
 pretty_datatype({string, S}) -> "the text \"" ++ S ++ "\"";
 pretty_datatype({tagged_string, {Tag, String}}) -> "the text \"" ++ String ++ "\"" ++ " tagged as \"" ++ Tag ++ "\"";
 pretty_datatype({atom, A}) -> "the text \"" ++ atom_to_list(A) ++ "\"";
@@ -250,6 +257,22 @@ pretty_datatype({flag, On, Off}) when is_atom(On), is_atom(Off) ->
 pretty_datatype({flag, {On,_}, {Off,_}}) ->
     ?FMT("~tp or ~tp", [On, Off]);
 pretty_datatype(_) -> "text". %% string and atom
+
+render_numeric_constraints(non_negative) -> " (non-negative)";
+render_numeric_constraints(positive)     -> " (positive)";
+render_numeric_constraints([])           -> "";
+render_numeric_constraints(Constraints) when is_list(Constraints) ->
+    " (" ++ string:join([render_constraint(C) || C <- Constraints], ", ") ++ ")".
+
+render_constraint(non_negative) -> "non-negative";
+render_constraint(positive)     -> "positive";
+render_constraint({min, N})     -> "min=" ++ format_number(N);
+render_constraint({max, N})     -> "max=" ++ format_number(N);
+render_constraint({gt,  N})     -> ">"    ++ format_number(N);
+render_constraint({lt,  N})     -> "<"    ++ format_number(N).
+
+format_number(N) when is_integer(N) -> integer_to_list(N);
+format_number(N) when is_float(N)   -> float_to_list(N, [{decimals, 6}, compact]).
 
 remove_duplicates(Conf) ->
     lists:foldl(

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -42,12 +42,25 @@
                     bytesize |
                     {percent, integer} |
                     {percent, float} |
+                    percent |
+                    port |
+                    byte |
+                    {integer, [numeric_constraint()] | numeric_shortcut()} |
+                    {float,   [numeric_constraint()] | numeric_shortcut()} |
                     float |
                     tagged_string |
                     regex |
                     uri |
                     {uri, [atom()]} |
                     {list, datatype()}.
+
+-type numeric_constraint() :: {min, number()}
+                            | {max, number()}
+                            | {gt,  number()}
+                            | {lt,  number()}
+                            | numeric_shortcut().
+
+-type numeric_shortcut() :: non_negative | positive.
 -type extended() :: { integer, integer() } |
                     { string, string() } |
                     { binary, binary() } |
@@ -101,6 +114,13 @@ is_supported({duration, ms}) -> true;
 is_supported(bytesize) -> true;
 is_supported({percent, integer}) -> true;
 is_supported({percent, float}) -> true;
+is_supported(percent) -> true;
+is_supported(port) -> true;
+is_supported(byte) -> true;
+is_supported({integer, Constraints}) ->
+    valid_constraints(Constraints, integer);
+is_supported({float, Constraints}) ->
+    valid_constraints(Constraints, float);
 is_supported(float) -> true;
 is_supported(tagged_string) -> true;
 is_supported(tagged_binary) -> true;
@@ -189,6 +209,14 @@ to_string("false", boolean) -> "false";
 
 to_string(Integer, integer) when is_integer(Integer) -> integer_to_list(Integer);
 to_string(Integer, integer) when is_list(Integer) -> Integer;
+
+to_string(Value, port) -> to_string(Value, integer);
+to_string(Value, byte) -> to_string(Value, integer);
+to_string(Value, percent) -> to_string(Value, {percent, integer});
+to_string(Value, {integer, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    to_string(Value, integer);
+to_string(Value, {float, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    to_string(Value, float);
 
 to_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> IP ++ ":" ++ integer_to_list(Port);
 to_string(IPString, ip) when is_list(IPString) -> IPString;
@@ -294,6 +322,21 @@ from_string(String, integer) when is_list(String) ->
     catch
         _:_ -> {error, {conversion, {String, integer}}}
     end;
+
+from_string(Value, port) ->
+    from_string(Value, {integer, [{min, 0}, {max, 65535}]});
+
+from_string(Value, byte) ->
+    from_string(Value, {integer, [{min, 0}, {max, 255}]});
+
+from_string(Value, percent) ->
+    from_string(Value, {percent, integer});
+
+from_string(Value, {integer, Constraints}) ->
+    apply_numeric_constraints(from_string(Value, integer), Constraints, integer);
+
+from_string(Value, {float, Constraints}) ->
+    apply_numeric_constraints(from_string(Value, float), Constraints, float);
 
 from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
 from_string(String, ip) when is_list(String) ->
@@ -585,6 +628,48 @@ validate_uri_schemes(Schemes) when is_list(Schemes) ->
         true -> ok;
         _    -> {error, {uri_schemes_invalid, Schemes}}
     end.
+
+valid_constraints(non_negative, _BaseType) -> true;
+valid_constraints(positive,     _BaseType) -> true;
+valid_constraints(Constraints, BaseType) when is_list(Constraints) ->
+    lists:all(fun(C) -> valid_constraint(C, BaseType) end, Constraints);
+valid_constraints(_, _) -> false.
+
+valid_constraint(non_negative, _) -> true;
+valid_constraint(positive,     _) -> true;
+valid_constraint({min, N}, T) -> is_bound(N, T);
+valid_constraint({max, N}, T) -> is_bound(N, T);
+valid_constraint({gt,  N}, T) -> is_bound(N, T);
+valid_constraint({lt,  N}, T) -> is_bound(N, T);
+valid_constraint(_, _) -> false.
+
+is_bound(N, integer) -> is_integer(N);
+is_bound(N, float)   -> is_number(N).
+
+apply_numeric_constraints({error, _} = E, _Constraints, _BaseType) ->
+    E;
+apply_numeric_constraints(Value, Constraints, BaseType) ->
+    check_constraints(Value, expand_constraints(Constraints, BaseType)).
+
+expand_constraints(non_negative, integer) -> [{min, 0}];
+expand_constraints(non_negative, float)   -> [{min, +0.0}];
+expand_constraints(positive, integer) -> [{min, 1}];
+expand_constraints(positive, float)   -> [{gt, +0.0}];
+expand_constraints(Constraints, BaseType) when is_list(Constraints) ->
+    lists:flatmap(fun(C) -> expand_constraints(C, BaseType) end, Constraints);
+expand_constraints(C, _BaseType) -> [C].
+
+check_constraints(Value, []) -> Value;
+check_constraints(Value, [Constraint | Rest]) ->
+    case satisfies(Value, Constraint) of
+        true  -> check_constraints(Value, Rest);
+        false -> {error, {range_violation, {Value, Constraint}}}
+    end.
+
+satisfies(V, {min, N}) -> V >= N;
+satisfies(V, {max, N}) -> V =< N;
+satisfies(V, {gt,  N}) -> V >  N;
+satisfies(V, {lt,  N}) -> V <  N.
 
 -ifdef(TEST).
 

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -212,6 +212,16 @@ xlate({uri_schemes_empty, _}) ->
 xlate({uri_schemes_invalid, Schemes}) ->
     io_lib:format("URI schemes must be a non-empty list of atoms, got ~tp",
                   [Schemes]);
+xlate({range_violation, {Value, {min, Bound}}}) ->
+    io_lib:format("~tp is below the minimum allowed value of ~tp",
+                  [Value, Bound]);
+xlate({range_violation, {Value, {max, Bound}}}) ->
+    io_lib:format("~tp exceeds the maximum allowed value of ~tp",
+                  [Value, Bound]);
+xlate({range_violation, {Value, {gt, Bound}}}) ->
+    io_lib:format("~tp must be strictly greater than ~tp", [Value, Bound]);
+xlate({range_violation, {Value, {lt, Bound}}}) ->
+    io_lib:format("~tp must be strictly less than ~tp", [Value, Bound]);
 xlate({schema_file, Filename, Inner}) ->
     ["in schema file \"", Filename, "\": ", xlate(Inner)];
 xlate({not_a_schema_file, Filename}) ->

--- a/test/cuttlefish_numerical_constraints_proper_tests.erl
+++ b/test/cuttlefish_numerical_constraints_proper_tests.erl
@@ -1,0 +1,215 @@
+-module(cuttlefish_numerical_constraints_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 500}, {to_file, user}]))).
+
+-import(cuttlefish_datatypes, [from_string/2]).
+
+
+%% Test entry points
+
+port_round_trip_test()         -> ?PROP(prop_port_round_trip()).
+port_rejects_out_of_range_test() -> ?PROP(prop_port_rejects_out_of_range()).
+byte_round_trip_test()         -> ?PROP(prop_byte_round_trip()).
+byte_rejects_out_of_range_test() -> ?PROP(prop_byte_rejects_out_of_range()).
+
+bounded_integer_accepts_in_range_test()  -> ?PROP(prop_bounded_integer_accepts_in_range()).
+bounded_integer_rejects_below_min_test() -> ?PROP(prop_bounded_integer_rejects_below_min()).
+bounded_integer_rejects_above_max_test() -> ?PROP(prop_bounded_integer_rejects_above_max()).
+
+non_negative_shortcut_equivalence_test() -> ?PROP(prop_non_negative_equivalence()).
+positive_integer_shortcut_equivalence_test() -> ?PROP(prop_positive_integer_equivalence()).
+
+empty_constraints_equivalent_to_plain_integer_test() ->
+    ?PROP(prop_empty_constraints_equivalent_to_plain_integer()).
+
+string_and_integer_input_agree_test() ->
+    ?PROP(prop_string_and_integer_input_agree()).
+
+bounded_float_accepts_in_range_test()  -> ?PROP(prop_bounded_float_accepts_in_range()).
+bounded_float_rejects_below_min_test() -> ?PROP(prop_bounded_float_rejects_below_min()).
+bounded_float_rejects_above_max_test() -> ?PROP(prop_bounded_float_rejects_above_max()).
+
+non_negative_float_shortcut_equivalence_test() ->
+    ?PROP(prop_non_negative_float_equivalence()).
+positive_float_shortcut_equivalence_test() ->
+    ?PROP(prop_positive_float_equivalence()).
+
+percent_accepts_zero_to_hundred_test() -> ?PROP(prop_percent_accepts_zero_to_hundred()).
+percent_rejects_out_of_range_test()    -> ?PROP(prop_percent_rejects_out_of_range()).
+
+integer_gt_lt_correctness_test() -> ?PROP(prop_integer_gt_lt_correctness()).
+
+
+%% Properties
+
+prop_port_round_trip() ->
+    ?FORALL(N, range(0, 65535),
+        N =:= from_string(N, port) andalso
+        N =:= from_string(integer_to_list(N), port)).
+
+prop_port_rejects_out_of_range() ->
+    ?FORALL(N, oneof([range(-1000, -1), range(65536, 100000)]),
+        case from_string(N, port) of
+            {error, {range_violation, {N, {min, 0}}}}     -> true;
+            {error, {range_violation, {N, {max, 65535}}}} -> true;
+            _ -> false
+        end).
+
+prop_byte_round_trip() ->
+    ?FORALL(N, range(0, 255),
+        N =:= from_string(N, byte)).
+
+prop_byte_rejects_out_of_range() ->
+    ?FORALL(N, oneof([range(-1000, -1), range(256, 100000)]),
+        case from_string(N, byte) of
+            {error, {range_violation, {N, {min, 0}}}}   -> true;
+            {error, {range_violation, {N, {max, 255}}}} -> true;
+            _ -> false
+        end).
+
+prop_bounded_integer_accepts_in_range() ->
+    ?FORALL({Min, Max}, valid_range(),
+        ?FORALL(N, range(Min, Max),
+            N =:= from_string(N, {integer, [{min, Min}, {max, Max}]}))).
+
+prop_bounded_integer_rejects_below_min() ->
+    ?FORALL({Min, Max}, valid_range(),
+        ?FORALL(N, integer_below(Min),
+            case from_string(N, {integer, [{min, Min}, {max, Max}]}) of
+                {error, {range_violation, {N, {min, Min}}}} -> true;
+                _ -> false
+            end)).
+
+prop_bounded_integer_rejects_above_max() ->
+    ?FORALL({Min, Max}, valid_range(),
+        ?FORALL(N, integer_above(Max),
+            case from_string(N, {integer, [{min, Min}, {max, Max}]}) of
+                {error, {range_violation, {N, {max, Max}}}} -> true;
+                _ -> false
+            end)).
+
+prop_non_negative_equivalence() ->
+    ?FORALL(N, integer(),
+        from_string(N, {integer, non_negative}) =:=
+        from_string(N, {integer, [{min, 0}]})).
+
+prop_positive_integer_equivalence() ->
+    ?FORALL(N, integer(),
+        from_string(N, {integer, positive}) =:=
+        from_string(N, {integer, [{min, 1}]})).
+
+prop_empty_constraints_equivalent_to_plain_integer() ->
+    ?FORALL(N, integer(),
+        from_string(N, integer) =:= from_string(N, {integer, []})).
+
+prop_string_and_integer_input_agree() ->
+    ?FORALL({N, Min, Max}, {integer(), integer(), integer()},
+        begin
+            T = {integer, [{min, Min}, {max, Max}]},
+            from_string(N, T) =:= from_string(integer_to_list(N), T)
+        end).
+
+prop_bounded_float_accepts_in_range() ->
+    ?FORALL({Min, Max}, valid_float_range(),
+        ?FORALL(F, float_in(Min, Max),
+            F =:= from_string(F, {float, [{min, Min}, {max, Max}]}))).
+
+prop_bounded_float_rejects_below_min() ->
+    ?FORALL({Min, Max}, valid_float_range(),
+        ?FORALL(F, float_below(Min),
+            case from_string(F, {float, [{min, Min}, {max, Max}]}) of
+                {error, {range_violation, {F, {min, Min}}}} -> true;
+                _ -> false
+            end)).
+
+prop_bounded_float_rejects_above_max() ->
+    ?FORALL({Min, Max}, valid_float_range(),
+        ?FORALL(F, float_above(Max),
+            case from_string(F, {float, [{min, Min}, {max, Max}]}) of
+                {error, {range_violation, {F, {max, Max}}}} -> true;
+                _ -> false
+            end)).
+
+prop_non_negative_float_equivalence() ->
+    ?FORALL(F, float(),
+        from_string(F, {float, non_negative}) =:=
+        from_string(F, {float, [{min, +0.0}]})).
+
+prop_positive_float_equivalence() ->
+    ?FORALL(F, float(),
+        from_string(F, {float, positive}) =:=
+        from_string(F, {float, [{gt, +0.0}]})).
+
+prop_percent_accepts_zero_to_hundred() ->
+    ?FORALL(N, range(0, 100),
+        N =:= from_string(N, percent) andalso
+        N =:= from_string(integer_to_list(N) ++ "%", percent)).
+
+prop_percent_rejects_out_of_range() ->
+    ?FORALL(N, oneof([range(-1000, -1), range(101, 1000)]),
+        case from_string(N, percent) of
+            {error, {range, _}} -> true;
+            _ -> false
+        end).
+
+prop_integer_gt_lt_correctness() ->
+    ?FORALL({N, Bound}, {integer(), integer()},
+        begin
+            GtResult = from_string(N, {integer, [{gt, Bound}]}),
+            LtResult = from_string(N, {integer, [{lt, Bound}]}),
+            GtOk = case N > Bound of
+                       true  -> GtResult =:= N;
+                       false -> match_range_violation(GtResult, N, {gt, Bound})
+                   end,
+            LtOk = case N < Bound of
+                       true  -> LtResult =:= N;
+                       false -> match_range_violation(LtResult, N, {lt, Bound})
+                   end,
+            GtOk andalso LtOk
+        end).
+
+match_range_violation({error, {range_violation, {V, C}}}, V, C) -> true;
+match_range_violation(_, _, _) -> false.
+
+
+%% Generators
+
+valid_range() ->
+    ?LET({A, B}, {integer(), integer()},
+         case A =< B of
+             true  -> {A, B};
+             false -> {B, A}
+         end).
+
+integer_below(Min) ->
+    ?LET(D, pos_integer(), Min - D).
+
+integer_above(Max) ->
+    ?LET(D, pos_integer(), Max + D).
+
+%% Generate {Min, Max} with a guaranteed positive gap so the
+%% in-range/out-of-range generators below can always produce a value.
+valid_float_range() ->
+    ?LET({A, B, Gap}, {float(), float(), ?SUCHTHAT(G, float(), G > 0.0)},
+         begin
+             Lo = min(A, B),
+             Hi = max(A, B),
+             {Lo, Hi + Gap}
+         end).
+
+float_in(Min, Max) ->
+    %% Clamp the interpolated value back into [Min, Max] in case
+    %% floating-point arithmetic drifts past either endpoint.
+    ?LET(P, choose(0, 1000),
+         max(Min, min(Max, Min + (Max - Min) * (P / 1000.0)))).
+
+float_below(Min) ->
+    ?LET(D, ?SUCHTHAT(F, float(), F > 0.0),
+         Min - D).
+
+float_above(Max) ->
+    ?LET(D, ?SUCHTHAT(F, float(), F > 0.0),
+         Max + D).

--- a/test/cuttlefish_numerical_constraints_tests.erl
+++ b/test/cuttlefish_numerical_constraints_tests.erl
@@ -1,0 +1,364 @@
+-module(cuttlefish_numerical_constraints_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(cuttlefish_datatypes, [from_string/2, to_string/2, is_supported/1]).
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+
+%% is_supported/1
+
+port_byte_percent_aliases_are_supported_test() ->
+    ?assert(is_supported(port)),
+    ?assert(is_supported(byte)),
+    ?assert(is_supported(percent)).
+
+bounded_integer_is_supported_test() ->
+    ?assert(is_supported({integer, [{min, 0}]})),
+    ?assert(is_supported({integer, [{max, 100}]})),
+    ?assert(is_supported({integer, [{min, 0}, {max, 65535}]})),
+    ?assert(is_supported({integer, [{gt, 0}]})),
+    ?assert(is_supported({integer, [{lt, 1024}]})),
+    ?assert(is_supported({integer, [{min, 0}, {max, 65535}, {gt, -1}]})).
+
+bounded_float_is_supported_test() ->
+    ?assert(is_supported({float, [{min, 0.0}]})),
+    ?assert(is_supported({float, [{max, 1.0}]})),
+    ?assert(is_supported({float, [{min, 0.0}, {max, 1.0}]})),
+    %% Integer bounds on a float type are allowed; comparison is polymorphic
+    ?assert(is_supported({float, [{min, 0}]})).
+
+integer_bound_works_on_float_type_test() ->
+    T = {float, [{min, 0}, {max, 1}]},
+    ?assertEqual(0.5, from_string("0.5", T)),
+    ?assertMatch({error, {range_violation, _}}, from_string(1.5, T)).
+
+empty_constraint_list_is_supported_test() ->
+    ?assert(is_supported({integer, []})),
+    ?assert(is_supported({float, []})).
+
+shortcut_constraints_are_supported_test() ->
+    ?assert(is_supported({integer, non_negative})),
+    ?assert(is_supported({integer, positive})),
+    ?assert(is_supported({float, non_negative})),
+    ?assert(is_supported({float, positive})),
+    ?assert(is_supported({integer, [non_negative, {max, 1000}]})),
+    ?assert(is_supported({integer, [positive]})).
+
+invalid_constraints_are_rejected_test() ->
+    ?assertNot(is_supported({integer, [{min, "zero"}]})),
+    ?assertNot(is_supported({integer, [{nonsense, 42}]})),
+    ?assertNot(is_supported({integer, garbage_shortcut})),
+    ?assertNot(is_supported({integer, [{min, 1.5}]})),
+    ?assertNot(is_supported({float, [{min, "zero"}]})),
+    ?assertNot(is_supported({float, [bogus]})).
+
+
+%% port
+
+port_accepts_valid_string_input_test() ->
+    ?assertEqual(0,     from_string("0",     port)),
+    ?assertEqual(5672,  from_string("5672",  port)),
+    ?assertEqual(65535, from_string("65535", port)).
+
+port_accepts_valid_integer_input_test() ->
+    ?assertEqual(5672, from_string(5672, port)).
+
+port_rejects_negative_values_test() ->
+    Result = from_string(-1, port),
+    ?assertMatch({error, {range_violation, {-1, {min, 0}}}}, Result),
+    ?assertEqual("-1 is below the minimum allowed value of 0", ?XLATE(Result)).
+
+port_rejects_values_above_65535_test() ->
+    Result = from_string(65536, port),
+    ?assertMatch({error, {range_violation, {65536, {max, 65535}}}}, Result),
+    ?assertEqual("65536 exceeds the maximum allowed value of 65535", ?XLATE(Result)).
+
+port_rejects_non_numeric_input_test() ->
+    ?assertMatch({error, {conversion, {"http", integer}}},
+                 from_string("http", port)).
+
+port_to_string_round_trip_test() ->
+    ?assertEqual("5672", to_string(5672, port)),
+    ?assertEqual("0", to_string(0, port)).
+
+
+%% byte
+
+byte_accepts_full_range_test() ->
+    ?assertEqual(0,   from_string("0",   byte)),
+    ?assertEqual(127, from_string("127", byte)),
+    ?assertEqual(255, from_string("255", byte)).
+
+byte_rejects_negative_values_test() ->
+    ?assertMatch({error, {range_violation, {-1, {min, 0}}}},
+                 from_string(-1, byte)).
+
+byte_rejects_values_above_255_test() ->
+    Result = from_string(256, byte),
+    ?assertMatch({error, {range_violation, {256, {max, 255}}}}, Result),
+    ?assertEqual("256 exceeds the maximum allowed value of 255", ?XLATE(Result)).
+
+byte_to_string_test() ->
+    ?assertEqual("42", to_string(42, byte)).
+
+
+%% percent (alias for {percent, integer})
+
+percent_alias_accepts_zero_to_hundred_test() ->
+    ?assertEqual(0,   from_string("0%",   percent)),
+    ?assertEqual(50,  from_string("50%",  percent)),
+    ?assertEqual(100, from_string("100%", percent)).
+
+percent_alias_rejects_out_of_range_test() ->
+    ?assertMatch({error, {range, _}}, from_string("110%", percent)),
+    ?assertMatch({error, {range, _}}, from_string("-1%",  percent)).
+
+percent_alias_to_string_test() ->
+    ?assertEqual("10%", to_string(10, percent)).
+
+
+%% Generic {integer, [...]}
+
+bounded_integer_accepts_in_range_test() ->
+    T = {integer, [{min, 10}, {max, 20}]},
+    ?assertEqual(10, from_string("10", T)),
+    ?assertEqual(15, from_string(15,   T)),
+    ?assertEqual(20, from_string("20", T)).
+
+bounded_integer_rejects_below_min_test() ->
+    T = {integer, [{min, 10}, {max, 20}]},
+    ?assertMatch({error, {range_violation, {9, {min, 10}}}}, from_string(9, T)).
+
+bounded_integer_rejects_above_max_test() ->
+    T = {integer, [{min, 10}, {max, 20}]},
+    ?assertMatch({error, {range_violation, {21, {max, 20}}}}, from_string(21, T)).
+
+bounded_integer_reports_first_failing_constraint_test() ->
+    %% Constraint order in the declaration determines which violation is
+    %% reported when several would fail.
+    T1 = {integer, [{min, 10}, {max, 20}]},
+    T2 = {integer, [{max, 20}, {min, 10}]},
+    ?assertMatch({error, {range_violation, {5, {min, 10}}}}, from_string(5, T1)),
+    ?assertMatch({error, {range_violation, {5, {min, 10}}}}, from_string(5, T2)),
+    ?assertMatch({error, {range_violation, {99, {max, 20}}}}, from_string(99, T1)),
+    ?assertMatch({error, {range_violation, {99, {max, 20}}}}, from_string(99, T2)).
+
+bounded_integer_strict_comparisons_test() ->
+    Gt = {integer, [{gt, 0}]},
+    Lt = {integer, [{lt, 0}]},
+    ?assertEqual(1, from_string(1, Gt)),
+    ?assertMatch({error, {range_violation, {0, {gt, 0}}}}, from_string(0, Gt)),
+    ?assertEqual(-1, from_string(-1, Lt)),
+    ?assertMatch({error, {range_violation, {0, {lt, 0}}}}, from_string(0, Lt)).
+
+bounded_integer_strict_message_test() ->
+    ?assertEqual("0 must be strictly greater than 0",
+                 ?XLATE(from_string(0, {integer, [{gt, 0}]}))),
+    ?assertEqual("0 must be strictly less than 0",
+                 ?XLATE(from_string(0, {integer, [{lt, 0}]}))).
+
+empty_integer_constraints_behave_like_plain_integer_test() ->
+    ?assertEqual(42, from_string("42", {integer, []})),
+    ?assertEqual(-7, from_string(-7,   {integer, []})),
+    ?assertMatch({error, {conversion, _}}, from_string("nope", {integer, []})).
+
+integer_shortcut_non_negative_test() ->
+    T = {integer, non_negative},
+    ?assertEqual(0, from_string(0, T)),
+    ?assertEqual(7, from_string("7", T)),
+    ?assertMatch({error, {range_violation, {-1, {min, 0}}}}, from_string(-1, T)).
+
+integer_shortcut_positive_test() ->
+    T = {integer, positive},
+    ?assertEqual(1, from_string(1, T)),
+    ?assertMatch({error, {range_violation, {0, {min, 1}}}}, from_string(0, T)),
+    ?assertMatch({error, {range_violation, {-5, {min, 1}}}}, from_string(-5, T)).
+
+shortcuts_compose_inside_constraint_list_test() ->
+    T = {integer, [non_negative, {max, 100}]},
+    ?assertEqual(0,   from_string(0, T)),
+    ?assertEqual(100, from_string(100, T)),
+    ?assertMatch({error, {range_violation, {-1, {min, 0}}}},  from_string(-1, T)),
+    ?assertMatch({error, {range_violation, {101, {max, 100}}}}, from_string(101, T)).
+
+list_wrapped_positive_shortcut_test() ->
+    T = {integer, [positive]},
+    ?assertEqual(1, from_string(1, T)),
+    ?assertMatch({error, {range_violation, {0, {min, 1}}}}, from_string(0, T)).
+
+multiple_shortcuts_in_one_list_test() ->
+    %% Redundant but legal; both expand to {min, 0}/{min, 1}.
+    T = {integer, [non_negative, positive]},
+    ?assertEqual(1, from_string(1, T)),
+    ?assertMatch({error, {range_violation, {0, {min, 1}}}}, from_string(0, T)).
+
+bounded_integer_to_string_test() ->
+    ?assertEqual("65535", to_string(65535, {integer, [{min, 0}, {max, 65535}]})),
+    ?assertEqual("0",     to_string(0,     {integer, non_negative})).
+
+
+%% Generic {float, [...]}
+
+bounded_float_accepts_in_range_test() ->
+    T = {float, [{min, 0.0}, {max, 1.0}]},
+    ?assertEqual(0.0, from_string("0.0", T)),
+    ?assertEqual(0.5, from_string(0.5,   T)),
+    ?assertEqual(1.0, from_string("1.0", T)).
+
+bounded_float_rejects_out_of_range_test() ->
+    T = {float, [{min, 0.0}, {max, 1.0}]},
+    ?assertMatch({error, {range_violation, {-0.1, {min, +0.0}}}}, from_string(-0.1, T)),
+    ?assertMatch({error, {range_violation, {1.5,  {max, +1.0}}}}, from_string(1.5,  T)).
+
+float_shortcut_non_negative_test() ->
+    T = {float, non_negative},
+    ?assertEqual(0.0, from_string(0.0, T)),
+    ?assertMatch({error, {range_violation, {-0.5, {min, +0.0}}}}, from_string(-0.5, T)).
+
+%% `positive' on a float means strictly greater than 0 (unlike on integer
+%% where the natural smallest positive value is 1). Documented behaviour.
+float_shortcut_positive_is_strict_test() ->
+    T = {float, positive},
+    ?assertEqual(0.1, from_string(0.1, T)),
+    ?assertMatch({error, {range_violation, {+0.0, {gt, +0.0}}}}, from_string(0.0, T)).
+
+bounded_float_to_string_test() ->
+    ?assertEqual("0.5", to_string(0.5, {float, [{min, 0.0}, {max, 1.0}]})),
+    ?assertEqual("0.0", to_string(0.0, {float, non_negative})).
+
+string_to_bounded_float_test() ->
+    T = {float, [{min, 0.0}, {max, 1.0}]},
+    ?assertEqual(0.25, from_string("0.25", T)),
+    ?assertMatch({error, {range_violation, _}}, from_string("1.5", T)).
+
+empty_float_constraints_behave_like_plain_float_test() ->
+    ?assertEqual(3.14, from_string("3.14", {float, []})),
+    ?assertEqual(3.14, from_string(3.14,   {float, []})),
+    ?assertMatch({error, {conversion, _}}, from_string("nope", {float, []})).
+
+
+%% Regression: the new {integer, [Constraints]} and {float, [Constraints]}
+%% shapes must not be mistaken for the existing extended forms
+%% {integer, integer()} and {float, float()}.
+
+is_extended_does_not_match_constraint_form_test() ->
+    ?assertNot(cuttlefish_datatypes:is_extended({integer, [{min, 0}]})),
+    ?assertNot(cuttlefish_datatypes:is_extended({integer, non_negative})),
+    ?assertNot(cuttlefish_datatypes:is_extended({float,   [{min, 0.0}]})),
+    ?assertNot(cuttlefish_datatypes:is_extended({float,   non_negative})).
+
+is_extended_still_matches_classic_extended_forms_test() ->
+    ?assert(cuttlefish_datatypes:is_extended({integer, 42})),
+    ?assert(cuttlefish_datatypes:is_extended({float,   3.14})).
+
+
+%% Conversion-error precedence: a value that cannot be parsed produces a
+%% conversion error, not a range error.
+
+conversion_error_short_circuits_constraint_check_test() ->
+    Result = from_string("not_a_number", {integer, [{min, 0}, {max, 10}]}),
+    ?assertMatch({error, {conversion, {"not_a_number", integer}}}, Result),
+    Result2 = from_string("nope", {float, [{min, +0.0}]}),
+    ?assertMatch({error, {conversion, {"nope", float}}}, Result2).
+
+
+%% Composition with datatype lists.
+%%
+%% The classic `non_negative_integer' validator in `rabbit.schema' accepts
+%% the atom `infinity' as well as non-negative integers. The migration
+%% path for those mappings is the existing datatype-list mechanism:
+%% `{datatype, [{atom, infinity}, {integer, non_negative}]}'. These tests
+%% pin that composition.
+
+constrained_integer_is_valid_inside_datatype_list_test() ->
+    ?assert(cuttlefish_datatypes:is_valid_list(
+              [{atom, infinity}, {integer, non_negative}])),
+    ?assert(cuttlefish_datatypes:is_valid_list(
+              [{atom, infinity}, port])),
+    ?assert(cuttlefish_datatypes:is_valid_list(
+              [{atom, infinity}, {integer, [{min, 0}, {max, 1024}]}])).
+
+infinity_or_non_negative_integer_end_to_end_test() ->
+    %% Migration shape for the `non_negative_integer' validator that also
+    %% accepts `infinity'. Verified through the full pipeline so that the
+    %% list-of-datatypes resolution order (first match wins) is exercised.
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"x.limit\", \"app.limit\","
+        "  [{datatype, [{atom, infinity}, {integer, non_negative}]}]}."
+    ]),
+    ?assertEqual(infinity,
+                 lookup_app_value(app, limit,
+                                  cuttlefish_generator:map(
+                                    Schema, [{["x", "limit"], "infinity"}]))),
+    ?assertEqual(42,
+                 lookup_app_value(app, limit,
+                                  cuttlefish_generator:map(
+                                    Schema, [{["x", "limit"], "42"}]))).
+
+port_end_to_end_test() ->
+    Schema = cuttlefish_schema:strings([
+        "{mapping, \"x.port\", \"app.port\", [{datatype, port}]}."
+    ]),
+    ?assertEqual(5672,
+                 lookup_app_value(app, port,
+                                  cuttlefish_generator:map(
+                                    Schema, [{["x", "port"], "5672"}]))),
+    ?assertMatch({error, transform_datatypes, _},
+                 cuttlefish_generator:map(
+                   Schema, [{["x", "port"], "65536"}])).
+
+list_of_ports_test() ->
+    ?assertEqual([5672, 5673],
+                 from_string("5672, 5673", {list, port})),
+    %% A list mixes good entries and errors verbatim, matching plain
+    %% {list, integer} semantics. The pipeline surfaces the error.
+    ?assertMatch([5672, {error, {range_violation, _}}],
+                 from_string("5672, 99999", {list, port})).
+
+list_of_constrained_integers_test() ->
+    T = {list, {integer, [{min, 0}, {max, 100}]}},
+    ?assertEqual([10, 20, 30], from_string("10, 20, 30", T)),
+    ?assertMatch([_, {error, {range_violation, _}}, _],
+                 from_string("10, 200, 30", T)).
+
+
+pretty_datatype_port_test() ->
+    ?assertEqual("an integer in 0-65535 (TCP/UDP port)",
+                 cuttlefish_conf:pretty_datatype(port)).
+
+pretty_datatype_byte_test() ->
+    ?assertEqual("an integer in 0-255",
+                 cuttlefish_conf:pretty_datatype(byte)).
+
+pretty_datatype_percent_test() ->
+    ?assertEqual("an integer percent in 0-100, with a trailing '%' on string input",
+                 cuttlefish_conf:pretty_datatype(percent)).
+
+pretty_datatype_constrained_integer_test() ->
+    ?assertEqual("an integer (min=0, max=65535)",
+                 cuttlefish_conf:pretty_datatype(
+                   {integer, [{min, 0}, {max, 65535}]})),
+    ?assertEqual("an integer (non-negative)",
+                 cuttlefish_conf:pretty_datatype({integer, non_negative})),
+    ?assertEqual("an integer (positive)",
+                 cuttlefish_conf:pretty_datatype({integer, positive})),
+    ?assertEqual("an integer",
+                 cuttlefish_conf:pretty_datatype({integer, []})).
+
+pretty_datatype_constrained_float_test() ->
+    ?assertEqual("a float (min=0.0, max=1.0)",
+                 cuttlefish_conf:pretty_datatype(
+                   {float, [{min, 0.0}, {max, 1.0}]})),
+    ?assertEqual("a float (>0, <100)",
+                 cuttlefish_conf:pretty_datatype(
+                   {float, [{gt, 0}, {lt, 100}]})).
+
+pretty_datatype_classic_extended_integer_still_works_test() ->
+    ?assertEqual("the integer 42",
+                 cuttlefish_conf:pretty_datatype({integer, 42})).
+
+
+lookup_app_value(App, Key, GeneratorResult) ->
+    proplists:get_value(Key, proplists:get_value(App, GeneratorResult)).


### PR DESCRIPTION
Some typical validators can be built-in type options.