### PR TITLE
Introduce schema partials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,26 @@ the `merge` option in a mapping's proplist.
 | `{include_default, "name"}` | string | |
 | `{see, ["other.key"]}` | list | cross-references |
 
+A schema file may also contain `{include_partial, {App, "name"}, Opts}`
+at the top level — see the **Schema Partials** section below.
+
+## Schema Partials
+
+A partial is a reusable mapping block included into a schema with
+`{include_partial, {App, "name"}, [{prefix, ...}, {app_prefix, ...}]}.`
+The partial file lives at `<App>/priv/schema/<Name>.partial` and is
+resolved via `code:priv_dir(App)`. Expansion happens in
+`cuttlefish_partial:load/3` at parse time; downstream stages see normal
+mappings and translations.
+
+Partial files contain `{mapping, ...}`, `{validator, ...}`, and
+`{partial_translation, BareKey, fun(Conf, ConfPrefix, AppPrefix) ->
+_ end}` terms only. Plain `{translation, ...}` is rejected with a
+helpful error. Partials cannot nest.
+
+See **Schema Partials** in `REFERENCE.md` for the user-facing
+documentation, include arguments, override semantics, and examples.
+
 ## Alias System (added in 3.7.0)
 
 Aliases allow a mapping to accept deprecated conf keys transparently.
@@ -216,43 +236,17 @@ Merges an `advanced.config` proplist on top of a generated config. Simple
 
 ### `cuttlefish_datatypes`
 
-String-to-typed-value conversion. Supports: `integer`, `string`, `atom`,
-`boolean`, `float`, `bytesize`, `duration`, `ip`, `fqdn`, `flag`,
-`{enum, [...]}`, `tagged_string`, `tagged_binary`, `{list, T}`, etc.
+String-to-typed-value conversion. `from_string/2` is the main entry
+point and returns `{error, {conversion, ...}}` on a parse failure or
+`{error, {range_violation, ...}}` on a constraint failure.
 
-`boolean` accepts the atoms `true` or `false` and the strings `"true"` or
-`"false"` (case-sensitive). It replaces `{enum, [true, false]}`, which is
-heavily duplicated across plugin schemas. Use `flag` for settings written
-as on/off in the conf file.
-
-Numerical types accept range constraints. `{integer, [Constraint, ...]}`
-and `{float, [Constraint, ...]}` check the constraints in declaration
-order; the first failure wins. A constraint is one of `{min, N}`,
-`{max, N}`, `{gt, N}`, `{lt, N}`, or the shortcut atoms `non_negative`
-(`{min, 0}`) and `positive` (`{min, 1}` for integers, `{gt, 0}` for
-floats). A bare shortcut may stand in for the list: `{integer,
-non_negative}`. Three aliases cover common ranges:
-
-- `port` = `{integer, [{min, 0}, {max, 65535}]}` (accepts the full IANA
-  range, including `0` for "OS-assigned" semantics)
-- `byte` = `{integer, [{min, 0}, {max, 255}]}`
-- `percent` = `{percent, integer}` (0-100)
-
-Out-of-range values surface as
-`{error, {range_violation, {Value, FailedConstraint}}}`.
-
-For settings that accept the atom `infinity` in addition to a numeric
-value (the historical `non_negative_integer` validator pattern in
-`rabbit.schema`), compose the new constrained type with the existing
-datatype-list mechanism — first match wins:
-
-```erlang
-{datatype, [{atom, infinity}, {integer, non_negative}]}
-```
-
-`from_string/2` is the main entry point. Returns `{error, {conversion, ...}}`
-on a parse failure and `{error, {range_violation, ...}}` on a constraint
-failure.
+See the **Datatypes** section in `REFERENCE.md` for the full list of
+supported types (`integer`, `string`, `binary`, `atom`, `float`,
+`boolean`, `flag`, `{enum, _}`, `ip`, `fqdn`, `bytesize`, durations,
+percent, tagged types, lists, files, regex, URIs), the numerical range
+constraints (`{min, _}`, `{max, _}`, `{gt, _}`, `{lt, _}`,
+`non_negative`, `positive`), and the named aliases (`port`, `byte`,
+`percent`).
 
 ### `cuttlefish_variable`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,6 +10,7 @@ This document is the comprehensive reference for schema authors. It covers the s
   - [Fuzzy Variables](#fuzzy-variables)
   - [Aliases](#aliases)
   - [Collections](#collections)
+- [Schema Partials](#schema-partials)
 - [Datatypes](#datatypes)
 - [Translations](#translations)
 - [Validators](#validators)
@@ -167,6 +168,148 @@ After:
 
 ---
 
+## Schema Partials
+
+A partial is a reusable, parameterised block of mappings, validators, and translations that a schema can pull in with a single directive. Partials exist to remove the duplication that arises when many plugin schemas declare the same shape (TLS options, TCP listen options, proxy protocol) with only the conf-key and app-key prefixes differing.
+
+### Including a partial
+
+```erlang
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix,     "auth_http.ssl_options"},
+     {app_prefix, "rabbitmq_auth_backend_http.ssl_options"}]}.
+```
+
+The first element is an `{App, Name}` pair. The loader resolves the partial via `code:priv_dir(App)` — exactly the same mechanism RabbitMQ already uses to discover `.schema` files — so the lookup works identically in dev trees, eunit, escripts, `.ez` plugins, and OS packages, without any new search path or CLI flag.
+
+The partial file lives at `<App>/priv/schema/<Name>.partial`. The distinct extension keeps it out of `cuttlefish_schema:list_schemas/1`'s auto-discovery, so partials are only loaded when a schema explicitly includes them.
+
+Expansion happens at parse time, before the schema merger runs. Partial-produced mappings and translations are indistinguishable from inline ones to every downstream stage (defaults, datatype conversion, validation, translation, conf generation).
+
+### Include arguments
+
+| Argument | Required | Meaning |
+|----------|----------|---------|
+| `{prefix, S}` | yes | Prepended to every mapping's conf key; bound into partial-translation closures as `ConfPrefix`. Must be non-empty. |
+| `{app_prefix, S}` | yes | Prepended to every mapping's and translation's app key; bound as `AppPrefix`. Must be non-empty. |
+| `{exclude, [Name]}` | no | Drops a partial term when `Name` exactly equals a mapping's bare conf key, equals a translation's bare app key, or equals the first dotted segment of a mapping's bare conf key (section match). |
+| `{overrides, [{Name, Opt}]}` | no | For each `{Name, Opt}` pair, applies the option `Opt` (e.g. `{validators, [...]}`, `{default, _}`, `{datatype, _}`) to the partial mapping with that bare conf key, replacing any same-keyed option from the partial. Equivalent in effect to declaring a `[merge, Opt]` mapping with the full prefixed name after the include, but expressed inline at the include site. |
+| `{disable_with, Atom}` | no | Adds a guard mapping and translation that lets the user write `<prefix> = <Atom>` (and nothing else) as a one-line shortcut to disable the entire feature. Any other value is rejected with `cuttlefish:invalid/1`. Removes the per-consumer guard boilerplate (~10 lines per consumer). |
+
+Unknown options are rejected loudly at load time so a typo like `{predix, "..."}` fails immediately instead of silently defaulting. Names listed in `exclude` and `overrides` are also checked against the partial's contents — a misspelling like `{exclude, ["versiosns"]}` or `{overrides, [{"certfle", _}]}` produces a `partial_exclude_unmatched` or `partial_overrides_unmatched` error naming the unmatched entries rather than silently no-opping.
+
+### Partial file contents
+
+A `.partial` file contains three top-level forms:
+
+```erlang
+{mapping, "bare_conf_key", "bare_app_key", [Options]}.
+{validator, "name", "description", fun(Value) -> boolean() end}.
+{partial_translation, "bare_app_key",
+    fun(Conf, ConfPrefix, AppPrefix) -> term() end}.
+```
+
+**Mappings** are written with bare names. The loader prepends the include's `prefix` and `app_prefix`. Fuzzy `$name` segments work normally (they live in the suffix). Most mapping options pass through unchanged. Two are handled specially:
+
+- `{aliases, [...]}` is never prefix-rewritten — aliases are typically legacy absolute keys, not relative siblings.
+- `{see, [...]}` rewrites bare entries (those without a `.`) by prepending the conf prefix; dotted entries pass through as absolute references. All entries are tokenized so downstream code sees a uniform `[variable()]` shape.
+
+**Validators** pass through unchanged. Validator names are global; if the partial references `"pem_file"` but doesn't ship its own definition, the consuming schema (or another schema in the same merge) must provide it.
+
+**Partial translations** are funs of arity 3. The loader wraps each one in a normal `fun(Conf) -> _ end` closure that captures `ConfPrefix` and `AppPrefix`. The downstream pipeline sees a standard translation. Arity 2 or anything else is rejected. Plain `{translation, ...}` is rejected with a message pointing at `partial_translation` — the partial format uses the distinct head atom so a reader of the file knows immediately that the fun receives extra prefix arguments.
+
+**Gotcha — do not hardcode segment counts in partial translations.** A pattern like `[{[_, _, Key], Val} | _]` only matches when the include site happens to use a two-segment conf prefix; deeper or shallower prefixes silently fall through. Derive the trailing segment from the path instead:
+
+```erlang
+{partial_translation, "key",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(ConfPrefix ++ ".key", Conf) of
+            [{Path, V} | _] when is_list(Path) ->
+                {list_to_atom(lists:last(Path)), list_to_binary(V)};
+            _ ->
+                cuttlefish:unset()
+        end
+    end}.
+```
+
+### Example partial
+
+```erlang
+%% deps/rabbit/priv/schema/ssl_options.partial
+
+{mapping, "verify", "verify",
+    [{datatype, {enum, [verify_peer, verify_none]}},
+     {default, verify_none}]}.
+
+{mapping, "cacertfile", "cacertfile",
+    [{datatype, file},
+     {validators, ["pem_file"]},
+     {see, ["certfile"]}]}.
+
+{mapping, "certfile", "certfile",
+    [{datatype, file},
+     {validators, ["pem_file"]}]}.
+
+{mapping, "versions.$version", "versions",
+    [{datatype, atom}]}.
+
+{partial_translation, "versions",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(
+                 ConfPrefix ++ ".versions", Conf) of
+            []  -> cuttlefish:unset();
+            Set -> [V || {_, V} <- Set]
+        end
+    end}.
+```
+
+### Overriding partial content
+
+Consumer schemas extend or override a partial using the existing `merge` machinery — no new syntax:
+
+```erlang
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix,     "shovel.ssl"},
+     {app_prefix, "rabbitmq_shovel.ssl"}]}.
+
+%% Override one mapping's datatype:
+{mapping, "shovel.ssl.password", "rabbitmq_shovel.ssl.password",
+    [merge, {datatype, string}]}.
+
+%% Replace one translation:
+{translation, "rabbitmq_shovel.ssl.versions",
+    fun(_Conf) -> custom_value end}.
+
+%% Add a sibling mapping that isn't in the partial:
+{mapping, "shovel.ssl.cacerts.$name", "rabbitmq_shovel.ssl.cacerts",
+    [{datatype, binary}]}.
+```
+
+The merger's last-write-wins rule applies: an inline translation with the same fully-qualified app key as a partial-produced one replaces it.
+
+### Multiple contexts in one schema
+
+A schema can include the same partial multiple times with distinct prefixes — for example, `rabbit.schema` uses this for its four `ssl_options` contexts (primary listener, definitions HTTPS, AMQP 0-9-1 client, AMQP 1.0 client):
+
+```erlang
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "ssl_options"}, {app_prefix, "rabbit.ssl_options"}]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "definitions.tls"}, {app_prefix, "rabbit.definitions.ssl_options"}]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "amqp_client.ssl_options"}, {app_prefix, "amqp_client.ssl_options"}]}.
+```
+
+Key collisions are impossible because every emitted key carries the include-site prefix.
+
+### Restrictions
+
+- Partials cannot include other partials. Nested `include_partial` inside a `.partial` file is rejected at load time.
+- Plain `{translation, ...}` is rejected inside a partial — use `partial_translation` for the prefix-bound form.
+- Unknown top-level head atoms are rejected loudly.
+
+---
+
 ## Datatypes
 
 The `{datatype, T}` option specifies how a conf string value is parsed into an Erlang term. Multiple datatypes can be specified as a list; cuttlefish tries each in order and uses the first that succeeds.
@@ -178,6 +321,29 @@ Parses a decimal integer string. Erlang type: `integer()`.
 ```
 ring_size = 64
 ```
+
+#### Range constraints
+
+`{integer, [Constraint, ...]}` checks constraints in declaration order; the first failure wins. A constraint is one of `{min, N}`, `{max, N}`, `{gt, N}`, `{lt, N}`, or the shortcut atoms `non_negative` (= `{min, 0}`) and `positive` (= `{min, 1}`). A bare shortcut may stand in for the list: `{integer, non_negative}`.
+
+```erlang
+{datatype, {integer, [{min, 1}, {max, 65535}]}}
+{datatype, {integer, non_negative}}
+```
+
+Three named aliases cover common ranges:
+
+- `port` = `{integer, [{min, 0}, {max, 65535}]}` (accepts the full IANA range, including `0` for "OS-assigned" semantics)
+- `byte` = `{integer, [{min, 0}, {max, 255}]}`
+- `percent` = `{percent, integer}` (0-100)
+
+For settings that accept the atom `infinity` in addition to a numeric value, compose with the existing datatype-list mechanism — first match wins:
+
+```erlang
+{datatype, [{atom, infinity}, {integer, non_negative}]}
+```
+
+Out-of-range values surface as `{error, {range_violation, {Value, FailedConstraint}}}`.
 
 ### `string`
 
@@ -210,6 +376,18 @@ Parses a floating-point string. Erlang type: `float()`.
 ```
 threshold = 0.75
 ```
+
+Floats accept the same range constraints as integers (`{min, N}`, `{max, N}`, `{gt, N}`, `{lt, N}`, `non_negative`, `positive`). For floats, `positive` is `{gt, 0}`. See the integer section above.
+
+### `boolean`
+
+Parses `true`/`false`. Erlang type: `boolean()`. Accepts the atoms `true` or `false` and the strings `"true"` or `"false"` (case-sensitive).
+
+```
+metrics.enabled = true
+```
+
+`boolean` replaces `{enum, [true, false]}`, which is heavily duplicated across plugin schemas. Use `flag` instead when the conf file convention is `on`/`off`.
 
 ### `flag`
 

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -174,6 +174,10 @@ xlate({alias_shadows_canonical, {Alias, OwnerMapping}}) ->
 xlate({alias_claimed_by_multiple_mappings, {Alias, Mapping1, Mapping2}}) ->
     io_lib:format("Alias ~ts is claimed by both ~ts and ~ts",
                   [Alias, Mapping1, Mapping2]);
+xlate({validator_not_defined, Variable, ValidatorName}) ->
+    io_lib:format("Mapping ~ts references validator '~ts', but no "
+                  "such validator is defined in any loaded schema",
+                  [Variable, ValidatorName]);
 xlate({unsupported_collect_type, {proplist, binary}}) ->
     "collect type {proplist, binary} is not supported; "
     "use {proplist, atom} for atom keys or {map, binary} for binary keys";
@@ -222,6 +226,74 @@ xlate({range_violation, {Value, {gt, Bound}}}) ->
     io_lib:format("~tp must be strictly greater than ~tp", [Value, Bound]);
 xlate({range_violation, {Value, {lt, Bound}}}) ->
     io_lib:format("~tp must be strictly less than ~tp", [Value, Bound]);
+xlate({partial_app_not_loadable, App, {"no such file or directory", _}}) ->
+    io_lib:format("Could not load OTP application '~ts' to resolve "
+                  "partial: its .app file is not on the code path. "
+                  "Add '~ts' as a dependency, or put its ebin/ on the "
+                  "path with `code:add_pathz/1`", [App, App]);
+xlate({partial_app_not_loadable, App, Reason}) ->
+    io_lib:format("Could not load OTP application '~ts' to resolve "
+                  "partial: ~tp", [App, Reason]);
+xlate({partial_app_no_priv_dir, App}) ->
+    io_lib:format("OTP application '~ts' has no priv dir; cannot "
+                  "resolve partial", [App]);
+xlate({partial_file_not_found, App, Name, Path}) ->
+    io_lib:format("Partial '~ts' not found for app '~ts' at: ~ts",
+                  [Name, App, Path]);
+xlate({partial_file_read_error, App, Name, Path, Reason}) ->
+    io_lib:format("Could not read partial '~ts:~ts' at ~ts: ~tp",
+                  [App, Name, Path, Reason]);
+xlate({partial_file_too_large, {Path, Size, Limit}}) ->
+    io_lib:format("refused to parse partial ~ts: file size ~B bytes exceeds "
+                  "the partial size limit of ~B bytes",
+                  [Path, Size, Limit]);
+xlate({partial_file_invalid_unicode, Path}) ->
+    io_lib:format("partial file ~ts is not valid UTF-8", [Path]);
+xlate({partial_parse_error, App, Name, {erl_scan, Line}}) ->
+    io_lib:format("Error scanning partial '~ts:~ts' near line ~B",
+                  [App, Name, Line]);
+xlate({partial_parse_error, App, Name, {erl_parse, Line, Reason}}) ->
+    io_lib:format("Parse error in partial '~ts:~ts' near line ~B: ~ts",
+                  [App, Name, Line, Reason]);
+xlate({partial_unsupported_term, translation}) ->
+    "Partials may not contain '{translation, ...}' terms; use "
+    "'{partial_translation, Name, fun(Conf, ConfPrefix, AppPrefix) -> _ end}' "
+    "instead, which gets prefix-bound at include time";
+xlate({partial_unsupported_term, Tag}) ->
+    io_lib:format("Partials may not contain '~tp' terms "
+                  "(only mapping, validator, partial_translation)", [Tag]);
+xlate({partial_translation_bad_arity, BareKey, Arity}) ->
+    io_lib:format("Partial translation '~ts' has arity ~B; must be 3 "
+                  "(Conf, ConfPrefix, AppPrefix)", [BareKey, Arity]);
+xlate({partial_missing_prefix, App, Name}) ->
+    io_lib:format("Include of partial '~ts:~ts' is missing the required "
+                  "{prefix, _} argument", [App, Name]);
+xlate({partial_missing_app_prefix, App, Name}) ->
+    io_lib:format("Include of partial '~ts:~ts' is missing the required "
+                  "{app_prefix, _} argument", [App, Name]);
+xlate({partial_empty_prefix, App, Name}) ->
+    io_lib:format("Include of partial '~ts:~ts' has an empty prefix or "
+                  "app_prefix", [App, Name]);
+xlate({partial_unknown_include_opt, Opt}) ->
+    io_lib:format("Unknown include_partial option: ~tp", [Opt]);
+xlate({partial_include_in_partial, App, Name}) ->
+    io_lib:format("Partial '~ts:~ts' contains an include_partial term; "
+                  "partials cannot nest", [App, Name]);
+xlate({partial_exclude_unmatched, App, Name, Unmatched}) ->
+    io_lib:format("Include of partial '~ts:~ts': exclude name(s) "
+                  "do not match any mapping or partial_translation "
+                  "in the partial: ~ts",
+                  [App, Name, format_quoted_names(Unmatched)]);
+xlate({partial_overrides_unmatched, App, Name, Unmatched}) ->
+    io_lib:format("Include of partial '~ts:~ts': overrides name(s) "
+                  "do not match any mapping in the partial: ~ts",
+                  [App, Name, format_quoted_names(Unmatched)]);
+xlate({partial_bad_directive, BadDirective}) ->
+    io_lib:format("Malformed include_partial directive: ~tp; "
+                  "expected '{include_partial, {App, \"name\"}, Opts}' "
+                  "where App is an atom, name is a string, "
+                  "and Opts is a list",
+                  [BadDirective]);
 xlate({schema_file, Filename, Inner}) ->
     ["in schema file \"", Filename, "\": ", xlate(Inner)];
 xlate({not_a_schema_file, Filename}) ->
@@ -238,6 +310,9 @@ xlate({schema_file_read_error, {Filename, Reason}}) ->
     io_lib:format("could not read schema file ~ts: ~tp", [Filename, Reason]);
 xlate({schema_file_invalid_unicode, Filename}) ->
     io_lib:format("schema file ~ts is not valid UTF-8", [Filename]).
+
+format_quoted_names(Names) ->
+    lists:join(", ", [io_lib:format("'~ts'", [N]) || N <- Names]).
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->

--- a/src/cuttlefish_partial.erl
+++ b/src/cuttlefish_partial.erl
@@ -1,0 +1,472 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_partial: load and rewrite a reusable mapping block
+%%
+%% Copyright (c) 2026 Broadcom. All Rights Reserved. The term Broadcom
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_partial).
+
+-export([
+    load/3,
+    rewrite/2,
+    bind_translation/3,
+    is_partial_filename/1
+]).
+
+-type include_opt() :: {prefix, string()}
+                     | {app_prefix, string()}
+                     | {exclude, [string()]}
+                     | {overrides, [{string(), proplists:property()}]}
+                     | {disable_with, atom()}.
+
+-type partial_term() ::
+        {mapping, string(), string(), [proplists:property()]}
+      | {validator, string(), string(), fun((term()) -> boolean())}
+      | {partial_translation, string(),
+         fun((cuttlefish_conf:conf(), string(), string()) -> term())}.
+
+-type emitted_term() ::
+        {mapping, string(), string(), [proplists:property()]}
+      | {validator, string(), string(), fun((term()) -> boolean())}
+      | {translation, string(),
+         fun((cuttlefish_conf:conf()) -> term())}.
+
+-export_type([include_opt/0, partial_term/0]).
+
+-define(MAX_PARTIAL_BYTES, 8388608).
+
+-spec load(atom(), string(), [include_opt()]) ->
+    {ok, [emitted_term()]} | cuttlefish_error:error().
+load(App, Name, IncludeOpts) when is_atom(App), is_list(Name) ->
+    case validate_include_opts(App, Name, IncludeOpts) of
+        ok ->
+            case ensure_app_loaded(App) of
+                ok ->
+                    case resolve_path(App, Name) of
+                        {ok, Path} -> load_path(App, Name, Path, IncludeOpts);
+                        Err -> Err
+                    end;
+                Err -> Err
+            end;
+        Err -> Err
+    end.
+
+-spec rewrite([partial_term()], [include_opt()]) ->
+    {ok, [emitted_term()]} | cuttlefish_error:error().
+rewrite(Terms, IncludeOpts) ->
+    Prefix = proplists:get_value(prefix, IncludeOpts),
+    AppPrefix = proplists:get_value(app_prefix, IncludeOpts),
+    Exclude = proplists:get_value(exclude, IncludeOpts, []),
+    Overrides = proplists:get_value(overrides, IncludeOpts, []),
+    case rewrite_each(Terms, Prefix, AppPrefix, Exclude, Overrides, []) of
+        {ok, Rewritten} ->
+            case proplists:get_value(disable_with, IncludeOpts) of
+                undefined -> {ok, Rewritten};
+                Atom -> {ok, Rewritten ++ disable_with_terms(Prefix, AppPrefix, Atom)}
+            end;
+        Err -> Err
+    end.
+
+-spec bind_translation(Fun3, string(), string()) ->
+    fun((cuttlefish_conf:conf()) -> term())
+        when Fun3 :: fun((cuttlefish_conf:conf(), string(), string()) -> term()).
+bind_translation(Fun3, ConfPrefix, AppPrefix) ->
+    fun(Conf) -> Fun3(Conf, ConfPrefix, AppPrefix) end.
+
+%% True for paths ending in `.partial`. Useful for the same kind of
+%% pre-flight sanity checks `cuttlefish_schema` applies to `.schema`.
+-spec is_partial_filename(file:filename_all()) -> boolean().
+is_partial_filename(Filename) ->
+    filename:extension(Filename) =:= ".partial".
+
+%% ===================================================================
+%% Internal: include-opt validation
+%% ===================================================================
+
+validate_include_opts(App, Name, Opts) when is_list(Opts) ->
+    case lists:foldl(
+            fun(Opt, ok) -> validate_one_opt(Opt);
+               (_, Err)  -> Err
+            end, ok, Opts) of
+        ok ->
+            check_required(App, Name, Opts);
+        Err -> Err
+    end;
+validate_include_opts(_App, _Name, Other) ->
+    {error, {partial_unknown_include_opt, Other}}.
+
+validate_one_opt({prefix, V}) when is_list(V) -> ok;
+validate_one_opt({app_prefix, V}) when is_list(V) -> ok;
+validate_one_opt({exclude, L}) when is_list(L) ->
+    case lists:all(fun(E) -> is_list(E) andalso E =/= [] end, L) of
+        true -> ok;
+        false -> {error, {partial_unknown_include_opt, {exclude, L}}}
+    end;
+validate_one_opt({overrides, L}) when is_list(L) ->
+    case lists:all(fun({N, Opt}) ->
+                           is_list(N) andalso N =/= []
+                               andalso is_tuple(Opt) andalso tuple_size(Opt) >= 1;
+                      (_) -> false
+                   end, L) of
+        true -> ok;
+        false -> {error, {partial_unknown_include_opt, {overrides, L}}}
+    end;
+validate_one_opt({disable_with, V}) when is_atom(V), V =/= undefined -> ok;
+validate_one_opt(Other) ->
+    {error, {partial_unknown_include_opt, Other}}.
+
+check_required(App, Name, Opts) ->
+    case proplists:is_defined(prefix, Opts) of
+        false -> {error, {partial_missing_prefix, App, Name}};
+        true ->
+            case proplists:is_defined(app_prefix, Opts) of
+                false -> {error, {partial_missing_app_prefix, App, Name}};
+                true ->
+                    P = proplists:get_value(prefix, Opts),
+                    AP = proplists:get_value(app_prefix, Opts),
+                    case {P, AP} of
+                        {"", _} -> {error, {partial_empty_prefix, App, Name}};
+                        {_, ""} -> {error, {partial_empty_prefix, App, Name}};
+                        _ -> ok
+                    end
+            end
+    end.
+
+%% ===================================================================
+%% Internal: app + path resolution
+%% ===================================================================
+
+ensure_app_loaded(App) ->
+    case application:load(App) of
+        ok -> ok;
+        {error, {already_loaded, App}} -> ok;
+        {error, Reason} -> {error, {partial_app_not_loadable, App, Reason}}
+    end.
+
+resolve_path(App, Name) ->
+    case code:priv_dir(App) of
+        {error, bad_name} ->
+            {error, {partial_app_no_priv_dir, App}};
+        PrivDir ->
+            {ok, filename:join([PrivDir, "schema", Name ++ ".partial"])}
+    end.
+
+%% ===================================================================
+%% Internal: file load + parse
+%% ===================================================================
+
+load_path(App, Name, Path, IncludeOpts) ->
+    case file:read_file(Path) of
+        {ok, Bytes} ->
+            decode_and_parse(App, Name, Path, Bytes, IncludeOpts);
+        {error, enoent} ->
+            {error, {partial_file_not_found, App, Name, Path}};
+        {error, Reason} ->
+            {error, {partial_file_read_error, App, Name, Path, Reason}}
+    end.
+
+decode_and_parse(App, Name, Path, Bytes, IncludeOpts) ->
+    case byte_size(Bytes) > ?MAX_PARTIAL_BYTES of
+        true ->
+            {error, {partial_file_too_large,
+                     {Path, byte_size(Bytes), ?MAX_PARTIAL_BYTES}}};
+        false ->
+            case unicode:characters_to_list(Bytes) of
+                {incomplete, _, _} ->
+                    {error, {partial_file_invalid_unicode, Path}};
+                {error, _, _} ->
+                    {error, {partial_file_invalid_unicode, Path}};
+                Chardata when is_list(Chardata) ->
+                    scan_and_parse(App, Name, Chardata, IncludeOpts)
+            end
+    end.
+
+scan_and_parse(App, Name, Chardata, IncludeOpts) ->
+    case erl_scan:string(Chardata) of
+        {ok, Tokens, _} ->
+            Comments = erl_comment_scan:string(Chardata),
+            Forms = split_forms(Tokens),
+            case parse_forms(Forms, Comments, []) of
+                {ok, Terms} ->
+                    case sanitize(App, Name, Terms) of
+                        ok ->
+                            case validate_names_against_terms(App, Name, Terms, IncludeOpts) of
+                                ok -> rewrite(Terms, IncludeOpts);
+                                Err -> Err
+                            end;
+                        Err -> Err
+                    end;
+                {error, Inner} ->
+                    {error, {partial_parse_error, App, Name, Inner}}
+            end;
+        {error, {Line, erl_scan, _}, _} ->
+            {error, {partial_parse_error, App, Name, {erl_scan, Line}}}
+    end.
+
+%% Pre-flight: every `exclude` and `overrides` name on the include
+%% must match something in the partial. A typo (`{exclude,
+%% ["versiosns"]}') would otherwise silently no-op, leaving the
+%% author to discover the misconfiguration through a downstream test
+%% (or in production).
+validate_names_against_terms(App, Name, Terms, IncludeOpts) ->
+    MappingConfs = [K || {mapping, K, _, _} <- Terms],
+    TranslationApps = [K || {partial_translation, K, _} <- Terms],
+    Sections = [first_segment(K) || K <- MappingConfs],
+    ExcludeMatchable = MappingConfs ++ TranslationApps ++ Sections,
+    Exclude = proplists:get_value(exclude, IncludeOpts, []),
+    OverrideNames = [N || {N, _} <- proplists:get_value(overrides, IncludeOpts, [])],
+    case unmatched(Exclude, ExcludeMatchable) of
+        [] ->
+            case unmatched(OverrideNames, MappingConfs) of
+                [] -> ok;
+                Bad ->
+                    {error, {partial_overrides_unmatched, App, Name, Bad}}
+            end;
+        Bad ->
+            {error, {partial_exclude_unmatched, App, Name, Bad}}
+    end.
+
+unmatched(Names, Known) ->
+    [N || N <- Names, not lists:member(N, Known)].
+
+first_segment(Key) ->
+    [Seg | _] = string:split(Key, "."),
+    Seg.
+
+split_forms(Tokens) ->
+    split_forms(Tokens, [], []).
+
+split_forms([], [], Acc) ->
+    lists:reverse(Acc);
+split_forms([], Pending, Acc) ->
+    %% No trailing dot: keep the tail so `erl_parse` produces a
+    %% useful error rather than silently dropping it.
+    lists:reverse([lists:reverse(Pending) | Acc]);
+split_forms([{dot, _} = Dot | Rest], Pending, Acc) ->
+    Form = lists:reverse([Dot | Pending]),
+    split_forms(Rest, [], [Form | Acc]);
+split_forms([T | Rest], Pending, Acc) ->
+    split_forms(Rest, [T | Pending], Acc).
+
+parse_forms([], _Comments, Acc) ->
+    {ok, lists:reverse(Acc)};
+parse_forms([Tokens | Rest], Comments, Acc) ->
+    case erl_parse:parse_exprs(Tokens) of
+        {ok, Exprs} ->
+            {value, V, _} = erl_eval:exprs(Exprs, []),
+            parse_forms(Rest, Comments,
+                        [attach_form_comments(V, Tokens, Comments) | Acc]);
+        {error, {Line, erl_parse, Reason}} ->
+            {error, {erl_parse, Line, format_parse_reason(Reason)}}
+    end.
+
+%% For mapping forms, look up comments that sit above the form's first
+%% token and merge them into the form's options proplist as `{doc, _}`
+%% and `{see, _}`. Mirrors how `cuttlefish_schema:parse_schema/3` uses
+%% `comment_parser/1` and `get_see/1` to attach annotations to inline
+%% mappings.
+attach_form_comments({mapping, Var, Map, Opts}, Tokens, Comments)
+        when is_list(Opts) ->
+    FormLine = first_token_line(Tokens),
+    Above = comments_above(FormLine, Comments),
+    case extract_doc_and_see(Above) of
+        {[], []} ->
+            {mapping, Var, Map, Opts};
+        {Doc, See} ->
+            {mapping, Var, Map, merge_doc_see(Opts, Doc, See)}
+    end;
+attach_form_comments(V, _Tokens, _Comments) ->
+    V.
+
+first_token_line([Tok | _]) ->
+    case erl_scan:location(Tok) of
+        {Line, _Col} -> Line;
+        Line when is_integer(Line) -> Line
+    end.
+
+%% Returns flat text lines from every comment block whose line is
+%% strictly less than `FormLine`.
+comments_above(FormLine, Comments) ->
+    lists:flatmap(
+      fun({CLine, _Col, _N, Lines}) when CLine < FormLine -> Lines;
+         (_) -> []
+      end, Comments).
+
+%% Tiny `@doc` / `@see` parser that mirrors
+%% `cuttlefish_schema:comment_parser/1` but only keeps the two
+%% annotations a partial cares about.
+extract_doc_and_see(Lines) ->
+    Stripped = [strip_percent(L) || L <- Lines],
+    do_extract(Stripped, none, [], []).
+
+do_extract([], _Mode, DocAcc, SeeAcc) ->
+    {lists:reverse(DocAcc), lists:reverse(SeeAcc)};
+do_extract(["@doc " ++ Rest | Tail], _Mode, DocAcc, SeeAcc) ->
+    do_extract(Tail, doc, [Rest | DocAcc], SeeAcc);
+do_extract(["@see " ++ Rest | Tail], _Mode, DocAcc, SeeAcc) ->
+    do_extract(Tail, none, DocAcc, [Rest | SeeAcc]);
+do_extract(["@" ++ _ | Tail], _Mode, DocAcc, SeeAcc) ->
+    do_extract(Tail, none, DocAcc, SeeAcc);
+do_extract([Line | Tail], doc, DocAcc, SeeAcc) ->
+    do_extract(Tail, doc, [Line | DocAcc], SeeAcc);
+do_extract([_Line | Tail], Mode, DocAcc, SeeAcc) ->
+    do_extract(Tail, Mode, DocAcc, SeeAcc).
+
+strip_percent([$% | T]) -> strip_percent(T);
+strip_percent([$\s | T]) -> strip_percent(T);
+strip_percent(L) -> L.
+
+%% Prepend doc/see entries so they take precedence over anything
+%% already in the proplist, matching the inline-schema convention
+%% in `cuttlefish_schema:parse_schema/3`.
+merge_doc_see(Opts, Doc, See) ->
+    DocOpt = case Doc of [] -> []; _ -> [{doc, Doc}] end,
+    SeeOpt = case See of [] -> []; _ -> [{see, See}] end,
+    DocOpt ++ SeeOpt ++ Opts.
+
+format_parse_reason([H | _] = Reason) when is_list(H) ->
+    lists:flatten(Reason);
+format_parse_reason(Reason) ->
+    io_lib:format("~tp", [Reason]).
+
+%% Reject anything we can't safely rewrite. The errors here are the
+%% loud half of the design: a typo'd head atom or a plain `translation`
+%% inside a partial fails at load with a message naming the right form.
+sanitize(_App, _Name, []) ->
+    ok;
+sanitize(App, Name, [{mapping, _, _, Opts} | Rest]) when is_list(Opts) ->
+    sanitize(App, Name, Rest);
+sanitize(App, Name, [{validator, _, _, _} | Rest]) ->
+    sanitize(App, Name, Rest);
+sanitize(App, Name, [{partial_translation, _, _} | Rest]) ->
+    sanitize(App, Name, Rest);
+sanitize(_App, _Name, [{translation, _, _} | _]) ->
+    {error, {partial_unsupported_term, translation}};
+sanitize(App, Name, [{include_partial, _, _} | _]) ->
+    {error, {partial_include_in_partial, App, Name}};
+sanitize(_App, _Name, [Other | _]) when is_tuple(Other), tuple_size(Other) >= 1 ->
+    {error, {partial_unsupported_term, element(1, Other)}};
+sanitize(_App, _Name, [Other | _]) ->
+    {error, {partial_unsupported_term, Other}}.
+
+%% ===================================================================
+%% Internal: term rewriting
+%% ===================================================================
+
+rewrite_each([], _Prefix, _AppPrefix, _Exclude, _Overrides, Acc) ->
+    {ok, lists:reverse(Acc)};
+rewrite_each([Term | Rest], Prefix, AppPrefix, Exclude, Overrides, Acc) ->
+    case rewrite_term(Term, Prefix, AppPrefix, Exclude, Overrides) of
+        skip ->
+            rewrite_each(Rest, Prefix, AppPrefix, Exclude, Overrides, Acc);
+        {ok, Rewritten} ->
+            rewrite_each(Rest, Prefix, AppPrefix, Exclude, Overrides,
+                         [Rewritten | Acc]);
+        {error, _} = Err -> Err
+    end.
+
+rewrite_term({mapping, ConfKey, AppKey, Opts}, Prefix, AppPrefix, Exclude, Overrides) ->
+    case excluded(ConfKey, Exclude) of
+        true ->
+            skip;
+        false ->
+            NewOpts = apply_overrides(ConfKey,
+                                       rewrite_mapping_opts(Opts, Prefix),
+                                       Overrides),
+            {ok, {mapping,
+                  join_dot(Prefix, ConfKey),
+                  join_dot(AppPrefix, AppKey),
+                  NewOpts}}
+    end;
+rewrite_term({validator, _, _, _} = V, _Prefix, _AppPrefix, _Exclude, _Overrides) ->
+    {ok, V};
+rewrite_term({partial_translation, BareKey, Fun}, Prefix, AppPrefix, Exclude, _Overrides) ->
+    case excluded(BareKey, Exclude) of
+        true ->
+            skip;
+        false ->
+            case erlang:fun_info(Fun, arity) of
+                {arity, 3} ->
+                    {ok, {translation,
+                          join_dot(AppPrefix, BareKey),
+                          bind_translation(Fun, Prefix, AppPrefix)}};
+                {arity, Other} ->
+                    {error, {partial_translation_bad_arity, BareKey, Other}}
+            end
+    end.
+
+%% For each override targeting this mapping's bare conf key, prepend
+%% its option tuple to Opts. Proplist lookup returns the first match,
+%% so prepended overrides win over the partial's defaults.
+apply_overrides(ConfKey, Opts, Overrides) ->
+    ExtraOpts = [Opt || {Name, Opt} <- Overrides, Name =:= ConfKey],
+    ExtraOpts ++ Opts.
+
+%% Emit the historical "<prefix> = <atom>" disable shortcut so each
+%% consumer doesn't have to spell out the same guard mapping plus
+%% translation. The translation accepts only the specified atom and
+%% produces an empty proplist; any other value is rejected with the
+%% standard `cuttlefish:invalid` message.
+disable_with_terms(Prefix, AppPrefix, Atom) ->
+    [{mapping, Prefix, AppPrefix,
+        [{datatype, {enum, [Atom]}}]},
+     {translation, AppPrefix,
+        fun(Conf) ->
+            %% Guard equality against captured `Atom` (a pattern would
+            %% shadow it).
+            case cuttlefish:conf_get(Prefix, Conf, undefined) of
+                V when V =:= Atom -> [];
+                undefined -> cuttlefish:unset();
+                _ -> cuttlefish:invalid("Invalid " ++ Prefix)
+            end
+        end}].
+
+%% `exclude` matches the bare key exactly OR matches the first dotted
+%% segment of a mapping's bare conf key. A bare key with no dots is
+%% both "exact" and "section" so this collapses to a single rule.
+excluded(BareKey, Exclude) ->
+    lists:any(fun(E) -> matches_name_or_section(E, BareKey) end, Exclude).
+
+matches_name_or_section(E, E) -> true;
+matches_name_or_section(E, BareKey) ->
+    lists:prefix(E ++ ".", BareKey).
+
+rewrite_mapping_opts(Opts, Prefix) ->
+    [rewrite_one_opt(Opt, Prefix) || Opt <- Opts].
+
+rewrite_one_opt({see, List}, Prefix) when is_list(List) ->
+    {see, [rewrite_see_entry(E, Prefix) || E <- List]};
+rewrite_one_opt(Other, _Prefix) ->
+    Other.
+
+%% Bare names get the prefix prepended; dotted entries pass through
+%% as absolute references. Either way, the result is tokenized so
+%% that downstream `cuttlefish_mapping:see/1` returns the same
+%% `[variable()]` shape it returns for `@see` comment annotations.
+rewrite_see_entry(Entry, Prefix) when is_list(Entry) ->
+    Absolute = case lists:member($., Entry) of
+                   true -> Entry;
+                   false -> join_dot(Prefix, Entry)
+               end,
+    cuttlefish_variable:tokenize(Absolute);
+rewrite_see_entry(Other, _Prefix) ->
+    Other.
+
+join_dot([], Tail) -> Tail;
+join_dot(Prefix, Tail) -> Prefix ++ "." ++ Tail.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -129,9 +129,37 @@ filter({Translations, Mappings, Validators}) ->
 
     case validate_aliases(NewMappings) of
         ok ->
-            {Translations, NewMappings, Validators};
+            case validate_validator_refs(NewMappings, Validators) of
+                ok -> {Translations, NewMappings, Validators};
+                {errorlist, _} = Errors -> Errors
+            end;
         {errorlist, _} = Errors ->
             Errors
+    end.
+
+%% @doc Checks that every validator name referenced by a mapping's
+%% `{validators, [...]}` opt resolves to a defined validator.
+%% Without this, a typo or missing dependency only surfaces at
+%% validation phase as `validator_not_found', far from the actual
+%% cause.
+-spec validate_validator_refs([cuttlefish_mapping:mapping()],
+                              [cuttlefish_validator:validator()]) ->
+    ok | cuttlefish_error:errorlist().
+validate_validator_refs(Mappings, Validators) ->
+    Defined = sets:from_list(
+        [cuttlefish_validator:name(V) || V <- Validators]),
+    Missing = lists:flatmap(
+        fun(M) ->
+            Var = cuttlefish_variable:format(cuttlefish_mapping:variable(M)),
+            [{Var, N} || N <- cuttlefish_mapping:validators(M),
+                         not sets:is_element(N, Defined)]
+        end, Mappings),
+    case Missing of
+        [] -> ok;
+        _ ->
+            {errorlist,
+             [{error, {validator_not_defined, Var, N}}
+              || {Var, N} <- Missing]}
     end.
 
 %% @doc Validates that aliases don't collide with other mappings' canonical
@@ -252,9 +280,10 @@ looks_like_schema(Chardata) ->
             false
     end.
 
-has_schema_tag("mapping"     ++ _) -> true;
-has_schema_tag("translation" ++ _) -> true;
-has_schema_tag("validator"   ++ _) -> true;
+has_schema_tag("mapping"         ++ _) -> true;
+has_schema_tag("translation"     ++ _) -> true;
+has_schema_tag("validator"       ++ _) -> true;
+has_schema_tag("include_partial" ++ _) -> true;
 has_schema_tag(_) -> false.
 
 skip_whitespace_and_comments([C | T]) when C =:= $\s; C =:= $\t;
@@ -349,10 +378,48 @@ parse_schema(ScannedTokens, CommentTokens, {TAcc, MAcc, VAcc, EAcc}) ->
             {cuttlefish_translation:parse_and_merge(Return, TAcc), MAcc, VAcc, EAcc};
         {validator, Return} ->
             {TAcc, MAcc, cuttlefish_validator:parse_and_merge(Return, VAcc), EAcc};
+        {include_partial, {include_partial, {App, Name}, IncludeOpts}}
+                when is_atom(App), is_list(Name), is_list(IncludeOpts) ->
+            apply_partial(App, Name, IncludeOpts, {TAcc, MAcc, VAcc, EAcc});
+        {include_partial, BadDirective} ->
+            {TAcc, MAcc, VAcc,
+             [{error, {partial_bad_directive, BadDirective}} | EAcc]};
         Other ->
             {TAcc, MAcc, VAcc, [{error, {parse_schema, Other}} | EAcc]}
     end,
     parse_schema(TailTokens, TailComments, NewAcc).
+
+%% Load a partial and fold each rewritten term into the schema
+%% accumulators. Errors from the loader propagate as standard
+%% schema errors and don't abort the rest of the file.
+apply_partial(App, Name, IncludeOpts, Acc) ->
+    case cuttlefish_partial:load(App, Name, IncludeOpts) of
+        {ok, Terms} ->
+            Annotated = [annotate_partial_source(T, App, Name) || T <- Terms],
+            lists:foldl(fun apply_partial_term/2, Acc, Annotated);
+        {error, Reason} ->
+            {T, M, V, E} = Acc,
+            {T, M, V, [{error, Reason} | E]}
+    end.
+
+%% Prepend a provenance line to each partial-emitted mapping's doc
+%% so `cuttlefish describe' shows where it came from. Translations
+%% and validators have no doc field; pass them through.
+annotate_partial_source({mapping, Var, Map, Opts}, App, Name) ->
+    Provenance = lists:flatten(
+        io_lib:format("(from partial ~ts:~ts)", [App, Name])),
+    OldDoc = proplists:get_value(doc, Opts, []),
+    NewOpts = lists:keystore(doc, 1, Opts, {doc, [Provenance | OldDoc]}),
+    {mapping, Var, Map, NewOpts};
+annotate_partial_source(Other, _App, _Name) ->
+    Other.
+
+apply_partial_term({mapping, _, _, _} = Raw, {T, M, V, E}) ->
+    {T, cuttlefish_mapping:parse_and_merge(Raw, M), V, E};
+apply_partial_term({validator, _, _, _} = Raw, {T, M, V, E}) ->
+    {T, M, cuttlefish_validator:parse_and_merge(Raw, V), E};
+apply_partial_term({translation, _, _} = Raw, {T, M, V, E}) ->
+    {cuttlefish_translation:parse_and_merge(Raw, T), M, V, E}.
 
 parse_schema_tokens(Scanned) ->
     parse_schema_tokens(Scanned, []).
@@ -366,7 +433,9 @@ parse_schema_tokens(Scanned, Acc=[{dot, LineNo}|_]) ->
 parse_schema_tokens([H|Scanned], Acc) ->
     parse_schema_tokens(Scanned, [H|Acc]).
 
--spec parse(list()) -> { mapping | translation | validator, tuple()} | cuttlefish_error:error().
+-spec parse(list()) ->
+    {mapping | translation | validator | include_partial, tuple()}
+  | cuttlefish_error:error().
 parse(Scanned) ->
     case erl_parse:parse_exprs(Scanned) of
         {ok, Parsed} ->

--- a/test/cuttlefish_partial_inline_tests.erl
+++ b/test/cuttlefish_partial_inline_tests.erl
@@ -1,0 +1,51 @@
+-module(cuttlefish_partial_inline_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% `cuttlefish_partial:bind_translation/3` is a public helper; a
+%% schema author can call it from inside an inline `{translation,
+%% ...}` to use the same prefix-binding ergonomics partials provide
+%% without authoring a `.partial' file.
+
+bind_translation_inline_from_schema_test() ->
+    Schema =
+        "{mapping, \"x.versions.$v\", \"y.versions\", [{datatype, atom}]}.\n"
+        "{translation, \"y.versions\","
+        "    cuttlefish_partial:bind_translation("
+        "      fun(Conf, ConfPrefix, _AppPrefix) ->"
+        "          [V || {_, V} <- cuttlefish_variable:filter_by_prefix("
+        "                              ConfPrefix ++ \".versions\", Conf)]"
+        "      end, \"x\", \"y\")}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "versions", "tlsv1.3"], 'tlsv1.3'},
+            {["x", "versions", "tlsv1.2"], 'tlsv1.2'}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    Versions = proplists:get_value(versions, proplists:get_value(y, Config)),
+    ?assertEqual(lists:sort(['tlsv1.2', 'tlsv1.3']), lists:sort(Versions)).
+
+bind_translation_inline_reuses_same_fun_shape_twice_test() ->
+    %% A consumer with two contexts can bind the same fun shape
+    %% twice with different prefixes.
+    Schema =
+        "{mapping, \"a.versions.$v\", \"app_a.versions\", [{datatype, atom}]}.\n"
+        "{mapping, \"b.versions.$v\", \"app_b.versions\", [{datatype, atom}]}.\n"
+        "{translation, \"app_a.versions\","
+        "    cuttlefish_partial:bind_translation("
+        "      fun(Conf, P, _A) ->"
+        "          [V || {_, V} <- cuttlefish_variable:filter_by_prefix("
+        "                              P ++ \".versions\", Conf)]"
+        "      end, \"a\", \"app_a\")}.\n"
+        "{translation, \"app_b.versions\","
+        "    cuttlefish_partial:bind_translation("
+        "      fun(Conf, P, _A) ->"
+        "          [V || {_, V} <- cuttlefish_variable:filter_by_prefix("
+        "                              P ++ \".versions\", Conf)]"
+        "      end, \"b\", \"app_b\")}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["a", "versions", "tlsv1.3"], 'tlsv1.3'},
+            {["b", "versions", "tlsv1.2"], 'tlsv1.2'}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    ?assertEqual(['tlsv1.3'],
+                 proplists:get_value(versions, proplists:get_value(app_a, Config))),
+    ?assertEqual(['tlsv1.2'],
+                 proplists:get_value(versions, proplists:get_value(app_b, Config))).

--- a/test/cuttlefish_partial_integration_tests.erl
+++ b/test/cuttlefish_partial_integration_tests.erl
@@ -1,0 +1,436 @@
+-module(cuttlefish_partial_integration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+include_resolves_and_expands_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n",
+    {Translations, Mappings, _Validators} = cuttlefish_schema:strings([Schema]),
+    %% 4 mappings + 1 partial_translation in the fixture.
+    ?assertEqual(4, length(Mappings)),
+    ?assertEqual(1, length(Translations)).
+
+include_then_inline_merge_overrides_mapping_field_test() ->
+    add_fixture_path(),
+    %% Partial sets datatype = {enum, [verify_peer, verify_none]}
+    %% and default = verify_none for `verify`. Override the datatype
+    %% via the existing merge mechanism.
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n"
+        "{mapping, \"x.ssl_options.verify\", \"y_app.ssl_options.verify\",\n"
+        "    [merge, {datatype, atom}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Verify = find_mapping(["x", "ssl_options", "verify"], Mappings),
+    ?assertEqual([atom], cuttlefish_mapping:datatype(Verify)),
+    %% The default from the partial survives because merge field-merges.
+    ?assertEqual(verify_none, cuttlefish_mapping:default(Verify)).
+
+include_then_inline_translation_replaces_partial_translation_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n"
+        "{translation, \"y_app.ssl_options.versions\",\n"
+        "    fun(_Conf) -> custom_value end}.\n",
+    {Translations, _M, _V} = cuttlefish_schema:strings([Schema]),
+    [T] = [X || X <- Translations,
+                cuttlefish_translation:mapping(X) =:= "y_app.ssl_options.versions"],
+    Fun = cuttlefish_translation:func(T),
+    ?assertEqual(custom_value, Fun([])).
+
+include_same_partial_twice_with_distinct_prefixes_test() ->
+    %% Models rabbit.schema's pattern of four ssl_options contexts in
+    %% one file. With distinct prefixes, no key collision is possible.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"primary.ssl\"},\n"
+        "     {app_prefix, \"app.primary.ssl\"}]}.\n"
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"defs.ssl\"},\n"
+        "     {app_prefix, \"app.defs.ssl\"}]}.\n",
+    {Translations, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    %% 4 mappings per include + 1 translation per include = 10 terms.
+    ?assertEqual(8, length(Mappings)),
+    ?assertEqual(2, length(Translations)),
+    AllMappingVars = [cuttlefish_mapping:variable(M) || M <- Mappings],
+    ?assertEqual(lists:sort(AllMappingVars),
+                 lists:usort(AllMappingVars)),
+    AllAppKeys = [cuttlefish_translation:mapping(T) || T <- Translations],
+    ?assertEqual(lists:sort(AllAppKeys), lists:usort(AllAppKeys)).
+
+include_exclude_section_drops_mapping_and_translation_together_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {exclude, [\"versions\"]}]}.\n",
+    {Translations, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([], Translations),
+    Vars = [cuttlefish_mapping:variable(M) || M <- Mappings],
+    ?assertNot(lists:member(["x","ssl_options","versions","$version"], Vars)).
+
+include_exclude_exact_keeps_unrelated_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {exclude, [\"verify\"]}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Vars = [cuttlefish_mapping:variable(M) || M <- Mappings],
+    ?assertNot(lists:member(["x","ssl_options","verify"], Vars)),
+    ?assert(lists:member(["x","ssl_options","cacertfile"], Vars)).
+
+include_then_inline_addition_in_same_namespace_test() ->
+    %% A consumer extends the partial by adding a sibling mapping
+    %% with a partial-relative-looking variable. Both flow through.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n"
+        "{mapping, \"x.ssl_options.cacerts.$name\", \"y_app.ssl_options.cacerts\",\n"
+        "    [{datatype, string}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Vars = [cuttlefish_mapping:variable(M) || M <- Mappings],
+    ?assert(lists:member(["x","ssl_options","cacerts","$name"], Vars)).
+
+partial_source_is_prepended_to_each_emitted_mapping_doc_test() ->
+    %% Every mapping emitted by a partial gets a "(from partial App:Name)"
+    %% line at the head of its `doc` so `cuttlefish describe' shows the
+    %% source. Original doc lines from `@doc' comments in the partial
+    %% follow on subsequent lines.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"with_doc\"},\n"
+        "    [{prefix, \"x.ssl\"},\n"
+        "     {app_prefix, \"y.ssl\"}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Verify = find_mapping(["x", "ssl", "verify"], Mappings),
+    [Provenance | RestOfDoc] = cuttlefish_mapping:doc(Verify),
+    ?assertEqual("(from partial sample_app:with_doc)", Provenance),
+    ?assertEqual(["Sets the verify mode.", "Multiple lines are joined."],
+                 RestOfDoc).
+
+partial_source_appears_even_when_partial_mapping_has_no_doc_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl\"},\n"
+        "     {app_prefix, \"y.ssl\"}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    %% `verify' in example.partial has no @doc comment; provenance
+    %% becomes the sole doc line.
+    Verify = find_mapping(["x", "ssl", "verify"], Mappings),
+    ?assertEqual(["(from partial sample_app:example)"],
+                 cuttlefish_mapping:doc(Verify)).
+
+doc_and_see_annotations_flow_through_to_expanded_mappings_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"with_doc\"},\n"
+        "    [{prefix, \"x.ssl\"},\n"
+        "     {app_prefix, \"y.ssl\"}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Verify = find_mapping(["x", "ssl", "verify"], Mappings),
+    %% The partial-source provenance line is prepended; partial's own
+    %% @doc lines follow.
+    ?assertEqual(["(from partial sample_app:with_doc)",
+                  "Sets the verify mode.", "Multiple lines are joined."],
+                 cuttlefish_mapping:doc(Verify)),
+    ?assertEqual([["x", "ssl", "certfile"]],
+                 cuttlefish_mapping:see(Verify)).
+
+see_references_get_rewritten_through_pipeline_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Cacert = find_mapping(["x", "ssl_options", "cacertfile"], Mappings),
+    ?assertEqual([["x", "ssl_options", "certfile"]],
+                 cuttlefish_mapping:see(Cacert)).
+
+include_runtime_translation_uses_bound_prefix_test() ->
+    %% Verifies that the bound translation actually reads
+    %% prefix-rewritten conf keys at runtime.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n",
+    {Translations, _M, _V} = cuttlefish_schema:strings([Schema]),
+    [T] = Translations,
+    Fun = cuttlefish_translation:func(T),
+    Conf = [{["x", "ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+            {["x", "ssl_options", "versions", "tlsv1.2"], 'tlsv1.2'}],
+    Result = Fun(Conf),
+    ?assertEqual(lists:sort(['tlsv1.2', 'tlsv1.3']),
+                 lists:sort(Result)).
+
+include_failure_does_not_abort_rest_of_schema_test() ->
+    %% A bad include should produce an errorlist (the surrounding
+    %% schema can still be parsed; reporting all errors is the
+    %% existing cuttlefish_schema behaviour).
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {definitely_no_such_app_xyz, \"x\"},\n"
+        "    [{prefix, \"p\"}, {app_prefix, \"a\"}]}.\n"
+        "{mapping, \"unrelated\", \"unrelated\", [{datatype, atom}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Errors} = Result,
+    ?assert(lists:any(
+             fun({error, {partial_app_not_loadable, _, _}}) -> true;
+                (_) -> false
+             end, Errors)).
+
+full_pipeline_with_included_partial_produces_expected_app_config_test() ->
+    %% End-to-end: partial mapping + bound translation flow through
+    %% cuttlefish_generator:map/2 to produce a valid app.config.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "ssl_options", "verify"], verify_peer},
+            {["x", "ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+            {["x", "ssl_options", "versions", "tlsv1.2"], 'tlsv1.2'}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = proplists:get_value(ssl_options,
+                                  proplists:get_value(y_app, Config)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, SslOpts)),
+    Versions = proplists:get_value(versions, SslOpts),
+    ?assertEqual(lists:sort(['tlsv1.2', 'tlsv1.3']),
+                 lists:sort(Versions)).
+
+full_pipeline_applies_partial_defaults_test() ->
+    %% A partial mapping with `{default, _}` contributes that default
+    %% to the consumer's app.config when the conf is silent.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Config = cuttlefish_generator:map(SchemaTuple, []),
+    SslOpts = proplists:get_value(ssl_options,
+                                  proplists:get_value(y_app, Config)),
+    ?assertEqual(verify_none, proplists:get_value(verify, SslOpts)).
+
+include_and_inline_translation_coexist_in_same_schema_test() ->
+    %% A schema that includes a partial AND defines its own
+    %% unrelated mapping+translation: both arrive in the merged
+    %% schema. The inline mapping has a default so the translation
+    %% has a value to act on.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"}]}.\n"
+        "{mapping, \"top\", \"y_app.top\",\n"
+        "    [{datatype, atom}, {default, raw}]}.\n"
+        "{translation, \"y_app.top\",\n"
+        "    fun(Conf) -> {wrapped, cuttlefish:conf_get(\"top\", Conf)} end}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Config = cuttlefish_generator:map(SchemaTuple, []),
+    YApp = proplists:get_value(y_app, Config),
+    ?assertEqual({wrapped, raw}, proplists:get_value(top, YApp)).
+
+disable_with_end_to_end_disables_via_atom_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "ssl_options"], none}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    YApp = proplists:get_value(y_app, Config),
+    ?assertEqual([], proplists:get_value(ssl_options, YApp)).
+
+overrides_end_to_end_replaces_partial_field_test() ->
+    add_fixture_path(),
+    %% The fixture's `verify` mapping has default `verify_none`. The
+    %% override changes it to `verify_peer`.
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {overrides, [{\"verify\", {default, verify_peer}}]}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Config = cuttlefish_generator:map(SchemaTuple, []),
+    SslOpts = proplists:get_value(ssl_options,
+                                  proplists:get_value(y_app, Config)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, SslOpts)).
+
+exclude_typo_surfaces_through_strings_pipeline_test() ->
+    %% The pre-flight `exclude' name check fires inside the schema
+    %% parser path and surfaces as a normal cuttlefish errorlist.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {exclude, [\"definitely_not_there\"]}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Errors} = Result,
+    ?assert(lists:any(
+             fun({error, {partial_exclude_unmatched, _, _,
+                          ["definitely_not_there"]}}) -> true;
+                (_) -> false
+             end, Errors)).
+
+overrides_typo_surfaces_through_strings_pipeline_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {overrides, [{\"certfle\", {validators, [\"v\"]}}]}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Errors} = Result,
+    ?assert(lists:any(
+             fun({error, {partial_overrides_unmatched, _, _,
+                          ["certfle"]}}) -> true;
+                (_) -> false
+             end, Errors)).
+
+disable_with_translation_is_dropped_when_parent_absent_test() ->
+    %% When the user sets a sub-key but not the parent disable atom,
+    %% the guard translation is correctly dropped (no spurious
+    %% `cuttlefish:invalid' error). The sub-key still produces its
+    %% nested value.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"example\"},\n"
+        "    [{prefix, \"x.ssl_options\"},\n"
+        "     {app_prefix, \"y_app.ssl_options\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "ssl_options", "verify"], verify_peer}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = proplists:get_value(ssl_options,
+                                  proplists:get_value(y_app, Config)),
+    ?assertEqual(verify_peer, proplists:get_value(verify, SslOpts)),
+    %% No spurious empty list from the guard.
+    ?assertEqual([{verify, verify_peer}], SslOpts).
+
+malformed_include_directive_produces_meaningful_error_test() ->
+    %% A user typo that doesn't follow the {App, "name"} shape
+    %% surfaces as a partial_bad_directive error, not the generic
+    %% "Unknown parse return".
+    Schema = "{include_partial, \"rabbit:ssl_options\", []}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Errors} = Result,
+    ?assert(lists:any(
+             fun({error, {partial_bad_directive, _}}) -> true;
+                (_) -> false
+             end, Errors)).
+
+schema_starting_with_include_partial_is_recognised_test() ->
+    %% looks_like_schema accepts include_partial as a top-level tag.
+    add_fixture_path(),
+    Dir = unique_tmp_dir(),
+    Path = filename:join(Dir, "include_first.schema"),
+    Bytes = <<"{include_partial, {sample_app, \"empty\"},\n"
+              "    [{prefix, \"x\"}, {app_prefix, \"y\"}]}.\n">>,
+    ok = file:write_file(Path, Bytes),
+    try
+        ?assertMatch({_, _, _}, cuttlefish_schema:files([Path]))
+    after
+        file:delete(Path),
+        cleanup_dir(Dir)
+    end.
+
+partial_extension_is_not_picked_up_by_list_schemas_test() ->
+    %% Defence-in-depth: list_schemas must keep filtering on .schema,
+    %% so a partial dropped alongside a schema is never auto-loaded.
+    Dir = unique_tmp_dir(),
+    ok = file:write_file(filename:join(Dir, "a.schema"),
+                         <<"{mapping, \"a\", \"a\", []}.\n">>),
+    ok = file:write_file(filename:join(Dir, "b.partial"),
+                         <<"{mapping, \"b\", \"b\", []}.\n">>),
+    try
+        Files = cuttlefish_schema:list_schemas(Dir),
+        Names = [filename:basename(F) || F <- Files],
+        ?assertEqual(["a.schema"], Names)
+    after
+        cleanup_dir(Dir)
+    end.
+
+%% --- helpers ------------------------------------------------------
+
+add_fixture_path() ->
+    Ebin = fixture_ebin(),
+    ok = ensure_sample_app_file(Ebin),
+    true = filelib:is_dir(Ebin) orelse
+        erlang:error({fixture_ebin_missing, Ebin}),
+    code:add_pathz(Ebin),
+    ok.
+
+%% Write `sample_app.app` if absent; rebar3 .gitignore excludes
+%% `ebin/`, so the fixture .app file isn't carried in version control.
+ensure_sample_app_file(Ebin) ->
+    ok = filelib:ensure_dir(filename:join(Ebin, "marker")),
+    AppFile = filename:join(Ebin, "sample_app.app"),
+    case filelib:is_regular(AppFile) of
+        true  -> ok;
+        false ->
+            App = "{application, sample_app,\n"
+                  " [{description, \"Test fixture for cuttlefish partials\"},\n"
+                  "  {vsn, \"0.0.1\"},\n"
+                  "  {modules, []},\n"
+                  "  {registered, []},\n"
+                  "  {applications, [kernel, stdlib]},\n"
+                  "  {env, []}]}.\n",
+            ok = file:write_file(AppFile, App)
+    end.
+
+fixture_ebin() ->
+    %% Resolve from cuttlefish's lib_dir (always set during tests) up
+    %% 4 levels to the project root, then into the source-tree fixture.
+    %% Avoids depending on rebar3 copying test/fixtures into _build.
+    LibDir = code:lib_dir(cuttlefish),
+    Project = filename:absname(
+                filename:join([LibDir, "..", "..", "..", ".."])),
+    filename:join([Project, "test", "fixtures",
+                   "sample_app", "ebin"]).
+
+find_mapping(Var, Mappings) ->
+    case [M || M <- Mappings, cuttlefish_mapping:variable(M) =:= Var] of
+        [M] -> M;
+        [] -> erlang:error({mapping_not_found, Var});
+        Many -> erlang:error({multiple_mappings_for, Var, length(Many)})
+    end.
+
+unique_tmp_dir() ->
+    Path = filename:join(cuttlefish_paths:tmp_base(),
+                         "cuttlefish_partial_integration_"
+                         ++ integer_to_list(erlang:unique_integer([positive]))),
+    ok = file:make_dir(Path),
+    Path.
+
+cleanup_dir(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            lists:foreach(
+              fun(F) -> file:delete(filename:join(Dir, F)) end,
+              Files);
+        _ -> ok
+    end,
+    file:del_dir(Dir).

--- a/test/cuttlefish_partial_proper_tests.erl
+++ b/test/cuttlefish_partial_proper_tests.erl
@@ -1,0 +1,191 @@
+-module(cuttlefish_partial_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 200}, {to_file, user}]))).
+
+%% --- entry points -------------------------------------------------
+
+rewrite_pure_test() -> ?PROP(prop_rewrite_pure()).
+rewrite_idempotent_in_keys_test() -> ?PROP(prop_rewrite_idempotent_in_keys()).
+emitted_keys_carry_prefix_test() -> ?PROP(prop_emitted_keys_carry_prefix()).
+exclude_section_is_exact_segment_test() -> ?PROP(prop_exclude_section_is_exact_segment()).
+exclude_exact_drops_only_matches_test() -> ?PROP(prop_exclude_exact_drops_only_matches()).
+validator_passthrough_test() -> ?PROP(prop_validator_passthrough()).
+translation_binding_is_arity1_test() -> ?PROP(prop_translation_binding_is_arity1()).
+translation_binding_forwards_prefixes_test() -> ?PROP(prop_translation_binding_forwards_prefixes()).
+inline_equivalence_test() -> ?PROP(prop_inline_equivalence()).
+
+%% --- properties ---------------------------------------------------
+
+%% Rewriting is a pure function: same input -> same output.
+prop_rewrite_pure() ->
+    ?FORALL({Terms, Opts}, {gen_terms(), gen_include_opts()},
+        cuttlefish_partial:rewrite(Terms, Opts)
+            =:= cuttlefish_partial:rewrite(Terms, Opts)).
+
+%% Running the rewriter twice yields the same keys both times (the
+%% first pass already produced prefixed keys; the second pass with the
+%% same opts would double-prepend, so this property checks the more
+%% useful "outputs are stable across re-invocations" guarantee).
+prop_rewrite_idempotent_in_keys() ->
+    ?FORALL({Terms, Opts}, {gen_terms(), gen_include_opts()},
+        begin
+            R1 = cuttlefish_partial:rewrite(Terms, Opts),
+            R2 = cuttlefish_partial:rewrite(Terms, Opts),
+            R1 =:= R2
+        end).
+
+%% Every emitted mapping/translation carries the include's prefix.
+prop_emitted_keys_carry_prefix() ->
+    ?FORALL({Terms, Opts}, {gen_terms(), gen_include_opts()},
+        begin
+            {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+            Prefix = proplists:get_value(prefix, Opts),
+            AppPrefix = proplists:get_value(app_prefix, Opts),
+            lists:all(
+              fun({mapping, ConfKey, AppKey, _}) ->
+                      lists:prefix(Prefix ++ ".", ConfKey)
+                          andalso lists:prefix(AppPrefix ++ ".", AppKey);
+                 ({translation, AppKey, _}) ->
+                      lists:prefix(AppPrefix ++ ".", AppKey);
+                 ({validator, _, _, _}) ->
+                      true
+              end, Out)
+        end).
+
+%% Section match is first-segment-exact, not substring. A section
+%% name S drops every term whose bare conf key equals S or starts
+%% with `S.`, and nothing else.
+prop_exclude_section_is_exact_segment() ->
+    ?FORALL({Section, Tail}, {gen_segment(), gen_segment()},
+        ?IMPLIES(Section =/= Tail
+                 andalso not lists:prefix(Section ++ ".", Tail)
+                 andalso Tail =/= Section,
+            begin
+                Terms = [{mapping, Section, Section, []},
+                         {mapping, Section ++ ".sub", Section, []},
+                         {mapping, Section ++ "_extra", Section ++ "_extra", []},
+                         {mapping, Tail, Tail, []}],
+                Opts = base_opts() ++ [{exclude, [Section]}],
+                {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+                OutBares = [strip_prefix(K) || {mapping, K, _, _} <- Out],
+                %% `Section` and `Section.sub` are dropped;
+                %% `Section_extra` and `Tail` survive.
+                lists:sort(OutBares) =:= lists:sort([Section ++ "_extra", Tail])
+            end)).
+
+%% Exact-name exclude drops only the exact match.
+prop_exclude_exact_drops_only_matches() ->
+    ?FORALL(Bares, gen_unique_bare_keys(),
+        ?IMPLIES(Bares =/= [],
+            begin
+                [Target | Rest] = Bares,
+                Terms = [{mapping, B, B, []} || B <- Bares],
+                Opts = base_opts() ++ [{exclude, [Target]}],
+                {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+                OutBares = lists:sort([strip_prefix(K)
+                                       || {mapping, K, _, _} <- Out]),
+                ExpectSurvivors = lists:sort([B || B <- Rest, B =/= Target]),
+                OutBares =:= ExpectSurvivors
+            end)).
+
+%% Validators are passed through byte-for-byte.
+prop_validator_passthrough() ->
+    ?FORALL({Name, Desc, Opts}, {gen_segment(), gen_segment(),
+                                  gen_include_opts()},
+        begin
+            F = fun(_) -> true end,
+            V = {validator, Name, Desc, F},
+            cuttlefish_partial:rewrite([V], Opts) =:= {ok, [V]}
+        end).
+
+%% Any arity-3 partial_translation becomes an arity-1 closure.
+prop_translation_binding_is_arity1() ->
+    ?FORALL({BareKey, Opts}, {gen_segment(), gen_include_opts()},
+        begin
+            Term = {partial_translation, BareKey,
+                    fun(_C, _P, _A) -> ok end},
+            {ok, [Out]} = cuttlefish_partial:rewrite([Term], Opts),
+            {translation, _, Bound} = Out,
+            erlang:fun_info(Bound, arity) =:= {arity, 1}
+        end).
+
+%% The bound closure forwards the include's prefixes to the source fun.
+prop_translation_binding_forwards_prefixes() ->
+    ?FORALL({BareKey, Opts}, {gen_segment(), gen_include_opts()},
+        begin
+            Term = {partial_translation, BareKey,
+                    fun(C, P, A) -> {C, P, A} end},
+            {ok, [Out]} = cuttlefish_partial:rewrite([Term], Opts),
+            {translation, _, Bound} = Out,
+            P = proplists:get_value(prefix, Opts),
+            A = proplists:get_value(app_prefix, Opts),
+            Bound(some_conf) =:= {some_conf, P, A}
+        end).
+
+%% The strongest correctness property: expanding a partial via the
+%% rewriter is observationally equal to writing those same terms
+%% inline with the prefixes hand-applied. Pins the "pure macro
+%% expansion" guarantee.
+prop_inline_equivalence() ->
+    ?FORALL({Terms, Opts}, {gen_mappings_only(), gen_include_opts()},
+        begin
+            {ok, Expanded} = cuttlefish_partial:rewrite(Terms, Opts),
+            Inline = manual_rewrite(Terms, Opts),
+            Expanded =:= Inline
+        end).
+
+%% --- generators ---------------------------------------------------
+
+gen_include_opts() ->
+    ?LET({P, A}, {gen_segment(), gen_segment()},
+         [{prefix, P}, {app_prefix, A}]).
+
+base_opts() ->
+    [{prefix, "p"}, {app_prefix, "a"}].
+
+%% A safe, lowercase, alphanumeric segment of 1-8 chars. Avoids
+%% characters that would confuse the dotted prefix machinery.
+gen_segment() ->
+    ?LET(N, range(1, 8),
+         vector(N, oneof([range($a, $z), range($0, $9)]))).
+
+gen_unique_bare_keys() ->
+    ?LET(L, list(gen_segment()), lists:usort(L)).
+
+gen_terms() ->
+    list(oneof([gen_mapping(), gen_validator(), gen_partial_translation()])).
+
+gen_mappings_only() ->
+    list(gen_mapping()).
+
+gen_mapping() ->
+    ?LET({K, App}, {gen_segment(), gen_segment()},
+         {mapping, K, App, [{datatype, atom}]}).
+
+gen_validator() ->
+    ?LET({N, D}, {gen_segment(), gen_segment()},
+         {validator, N, D, fun(_) -> true end}).
+
+gen_partial_translation() ->
+    ?LET(K, gen_segment(),
+         {partial_translation, K, fun(_, _, _) -> ok end}).
+
+%% --- helpers ------------------------------------------------------
+
+strip_prefix(Key) ->
+    %% Strip the leading "p." that base_opts() prepends.
+    case Key of
+        "p." ++ Rest -> Rest;
+        _ -> Key
+    end.
+
+%% A deliberately naive "what the schema author would have written
+%% inline" — concatenate prefix.bare for mappings, no exclude.
+manual_rewrite(Terms, Opts) ->
+    Prefix = proplists:get_value(prefix, Opts),
+    AppPrefix = proplists:get_value(app_prefix, Opts),
+    [{mapping, Prefix ++ "." ++ K, AppPrefix ++ "." ++ App, OptsM}
+     || {mapping, K, App, OptsM} <- Terms].

--- a/test/cuttlefish_partial_rabbit_combined_tests.erl
+++ b/test/cuttlefish_partial_rabbit_combined_tests.erl
@@ -1,0 +1,113 @@
+-module(cuttlefish_partial_rabbit_combined_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+mqtt_shaped_plugin_schema_combines_both_partials_test() ->
+    add_fixture_path(),
+    Schema =
+        validators_schema() ++
+        "{include_partial, {sample_app, \"rabbit_ssl_options\"},\n"
+        "    [{prefix, \"mqtt.ssl_options\"},\n"
+        "     {app_prefix, \"pseudo_mqtt.ssl_options\"}]}.\n"
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"mqtt.tcp_listen_options\"},\n"
+        "     {app_prefix, \"pseudo_mqtt.tcp_listen_options\"},\n"
+        "     {disable_with, none}]}.\n"
+        "{mapping, \"mqtt.protocol_version\", \"pseudo_mqtt.protocol_version\",\n"
+        "    [{datatype, {enum, ['3.1.1', '5.0']}},\n"
+        "     {default, '5.0'}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [
+        {["mqtt", "ssl_options", "verify"],      verify_peer},
+        {["mqtt", "ssl_options", "cacertfile"], "/etc/ca.pem"},
+        {["mqtt", "ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+        {["mqtt", "tcp_listen_options", "port"],    1883},
+        {["mqtt", "tcp_listen_options", "backlog"], 256},
+        {["mqtt", "protocol_version"], '5.0'}
+    ],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    PseudoMqtt = proplists:get_value(pseudo_mqtt, Config),
+    SslOpts = proplists:get_value(ssl_options, PseudoMqtt),
+    TcpOpts = proplists:get_value(tcp_listen_options, PseudoMqtt),
+
+    ?assertEqual(verify_peer,  proplists:get_value(verify, SslOpts)),
+    ?assertEqual("/etc/ca.pem", proplists:get_value(cacertfile, SslOpts)),
+    ?assertEqual(['tlsv1.3'],   proplists:get_value(versions, SslOpts)),
+    ?assertEqual(1883,          proplists:get_value(port, TcpOpts)),
+    ?assertEqual(256,           proplists:get_value(backlog, TcpOpts)),
+    ?assertEqual('5.0',         proplists:get_value(protocol_version, PseudoMqtt)).
+
+provenance_is_attached_to_both_partials_mappings_test() ->
+    add_fixture_path(),
+    Schema =
+        validators_schema() ++
+        "{include_partial, {sample_app, \"rabbit_ssl_options\"},\n"
+        "    [{prefix, \"mqtt.ssl_options\"},\n"
+        "     {app_prefix, \"pseudo_mqtt.ssl_options\"}]}.\n"
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"mqtt.tcp_listen_options\"},\n"
+        "     {app_prefix, \"pseudo_mqtt.tcp_listen_options\"},\n"
+        "     {disable_with, none}]}.\n",
+    {_T, Mappings, _V} = cuttlefish_schema:strings([Schema]),
+    Verify = find_mapping(["mqtt", "ssl_options", "verify"], Mappings),
+    Port = find_mapping(["mqtt", "tcp_listen_options", "port"], Mappings),
+    [VerifyProv | _] = cuttlefish_mapping:doc(Verify),
+    [PortProv | _]   = cuttlefish_mapping:doc(Port),
+    ?assertEqual("(from partial sample_app:rabbit_ssl_options)", VerifyProv),
+    ?assertEqual("(from partial sample_app:rabbit_tcp_listen_options)", PortProv).
+
+%% --- helpers ------------------------------------------------------
+
+find_mapping(Var, Mappings) ->
+    case [M || M <- Mappings, cuttlefish_mapping:variable(M) =:= Var] of
+        [M] -> M;
+        [] -> erlang:error({mapping_not_found, Var})
+    end.
+
+validators_schema() ->
+    "{validator, \"pem_file\", \"must be a PEM file\","
+    "    fun(_) -> true end}.\n"
+    "{validator, \"file_accessible\", \"must be a readable file\","
+    "    fun(_) -> true end}.\n"
+    "{validator, \"byte\", \"must be in 0..255\","
+    "    fun(N) -> is_integer(N) andalso N >= 0 andalso N =< 255 end}.\n"
+    "{validator, \"port\", \"must be in 0..65535\","
+    "    fun(N) -> is_integer(N) andalso N >= 0 andalso N =< 65535 end}.\n"
+    "{validator, \"non_negative_integer\", \"must be >= 0\","
+    "    fun(N) -> is_integer(N) andalso N >= 0 end}.\n".
+
+add_fixture_path() ->
+    Ebin = fixture_ebin(),
+    ok = ensure_sample_app_file(Ebin),
+    true = filelib:is_dir(Ebin) orelse
+        erlang:error({fixture_ebin_missing, Ebin}),
+    code:add_pathz(Ebin),
+    ok.
+
+%% Write `sample_app.app` if absent; rebar3 .gitignore excludes
+%% `ebin/`, so the fixture .app file isn't carried in version control.
+ensure_sample_app_file(Ebin) ->
+    ok = filelib:ensure_dir(filename:join(Ebin, "marker")),
+    AppFile = filename:join(Ebin, "sample_app.app"),
+    case filelib:is_regular(AppFile) of
+        true  -> ok;
+        false ->
+            App = "{application, sample_app,\n"
+                  " [{description, \"Test fixture for cuttlefish partials\"},\n"
+                  "  {vsn, \"0.0.1\"},\n"
+                  "  {modules, []},\n"
+                  "  {registered, []},\n"
+                  "  {applications, [kernel, stdlib]},\n"
+                  "  {env, []}]}.\n",
+            ok = file:write_file(AppFile, App)
+    end.
+
+fixture_ebin() ->
+    %% Resolve from cuttlefish's lib_dir (always set during tests) up
+    %% 4 levels to the project root, then into the source-tree fixture.
+    %% Avoids depending on rebar3 copying test/fixtures into _build.
+    LibDir = code:lib_dir(cuttlefish),
+    Project = filename:absname(
+                filename:join([LibDir, "..", "..", "..", ".."])),
+    filename:join([Project, "test", "fixtures",
+                   "sample_app", "ebin"]).

--- a/test/cuttlefish_partial_rabbit_ssl_options_tests.erl
+++ b/test/cuttlefish_partial_rabbit_ssl_options_tests.erl
@@ -1,0 +1,476 @@
+-module(cuttlefish_partial_rabbit_ssl_options_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Real-world fidelity tests for the partial mechanism.
+%%
+%% The fixture at `test/fixtures/sample_app/priv/schema/rabbit_ssl_options.partial`
+%% is a verbatim copy of the production partial shipped in
+%% `deps/rabbit/priv/schema/ssl_options.partial` (rabbitmq-server).
+%% The validators it references (`pem_file`, `byte`, `file_accessible`)
+%% are normally defined in `rabbit.schema`; here they are injected via
+%% `rabbit_validators_schema/0`. The `rabbit_cuttlefish` stub at
+%% `test/fixtures/sample_app/src/rabbit_cuttlefish.erl` provides the
+%% `optionally_tagged_binary/2` helper the partial's password
+%% translation calls.
+
+%% --- single-context happy path ------------------------------------
+
+single_include_with_realistic_conf_produces_expected_app_config_test() ->
+    setup(),
+    Schema = compose(include_for("ssl_options", "rabbit.ssl_options")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [
+        {["ssl_options", "verify"], verify_peer},
+        {["ssl_options", "fail_if_no_peer_cert"], true},
+        {["ssl_options", "cacertfile"], "/etc/rabbitmq/ca.pem"},
+        {["ssl_options", "certfile"], "/etc/rabbitmq/cert.pem"},
+        {["ssl_options", "keyfile"], "/etc/rabbitmq/key.pem"},
+        {["ssl_options", "depth"], 3},
+        {["ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+        {["ssl_options", "versions", "tlsv1.2"], 'tlsv1.2'}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = lookup(rabbit, ssl_options, Config),
+    ?assertEqual(verify_peer, proplists:get_value(verify, SslOpts)),
+    ?assertEqual(true, proplists:get_value(fail_if_no_peer_cert, SslOpts)),
+    ?assertEqual("/etc/rabbitmq/ca.pem",
+                 proplists:get_value(cacertfile, SslOpts)),
+    ?assertEqual(3, proplists:get_value(depth, SslOpts)),
+    Versions = proplists:get_value(versions, SslOpts),
+    ?assertEqual(lists:sort(['tlsv1.2', 'tlsv1.3']),
+                 lists:sort(Versions)).
+
+%% --- multi-context (rabbit.schema's four-ssl_options pattern) ------
+
+four_contexts_in_one_schema_produce_independent_app_configs_test() ->
+    setup(),
+    Schema = compose(
+        include_for("ssl_options", "rabbit.ssl_options"),
+        include_for("definitions.tls", "rabbit.definitions.ssl_options"),
+        include_for("amqp_client.ssl_options", "amqp_client.ssl_options"),
+        include_for("amqp10_client.ssl_options", "amqp10_client.ssl_options")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [
+        {["ssl_options", "verify"], verify_peer},
+        {["definitions", "tls", "verify"], verify_none},
+        {["amqp_client", "ssl_options", "depth"], 1},
+        {["amqp10_client", "ssl_options", "depth"], 9}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    Rabbit = proplists:get_value(rabbit, Config),
+    ?assertEqual(verify_peer,
+                 proplists:get_value(verify,
+                     proplists:get_value(ssl_options, Rabbit))),
+    ?assertEqual(verify_none,
+                 proplists:get_value(verify,
+                     proplists:get_value(ssl_options,
+                         proplists:get_value(definitions, Rabbit)))),
+    ?assertEqual(1, proplists:get_value(depth,
+                       proplists:get_value(ssl_options,
+                           proplists:get_value(amqp_client, Config)))),
+    ?assertEqual(9, proplists:get_value(depth,
+                       proplists:get_value(ssl_options,
+                           proplists:get_value(amqp10_client, Config)))).
+
+%% --- override via merge (shovel-style password retype) -------------
+
+consumer_overrides_password_datatype_via_merge_test() ->
+    %% The merge changes the mapping's accepted datatype (string vs
+    %% the partial's [tagged_binary, binary]). The bound translation
+    %% from the partial still runs and converts the value to a
+    %% binary for app config; overriding the output shape would
+    %% require also redeclaring the translation.
+    setup(),
+    Schema = compose(
+        include_for("shovel.ssl", "rabbitmq_shovel.ssl"),
+        "{mapping, \"shovel.ssl.password\", \"rabbitmq_shovel.ssl.password\","
+        " [merge, {datatype, string}]}.\n"),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [{["shovel", "ssl", "password"], "plaintext-pw"}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = lookup(rabbitmq_shovel, ssl, Config),
+    ?assertEqual(<<"plaintext-pw">>, proplists:get_value(password, SslOpts)).
+
+%% --- override via inline translation (custom versions handling) ----
+
+consumer_replaces_versions_translation_test() ->
+    setup(),
+    Schema = compose(
+        include_for("x.ssl", "y.ssl"),
+        "{translation, \"y.ssl.versions\","
+        " fun(_Conf) -> ['custom-version'] end}.\n"),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [{["x", "ssl", "versions", "tlsv1.3"], 'tlsv1.3'}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    ?assertEqual(['custom-version'],
+                 proplists:get_value(versions,
+                                     lookup(y, ssl, Config))).
+
+%% --- exclude (drop a section the consumer doesn't expose) ----------
+
+consumer_excludes_log_level_section_test() ->
+    setup(),
+    Schema = compose(
+        "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+        " [{prefix, \"x.ssl\"}, {app_prefix, \"y.ssl\"},"
+        "  {exclude, [\"log_level\"]}]}.\n"),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    {_T, Mappings, _V} = SchemaTuple,
+    Vars = [cuttlefish_mapping:variable(M) || M <- Mappings],
+    ?assertNot(lists:member(["x", "ssl", "log_level"], Vars)),
+    ?assert(lists:member(["x", "ssl", "verify"], Vars)).
+
+%% --- key.* translation correctly tokenises and binarises -----------
+
+key_translation_assembles_tuple_correctly_test() ->
+    setup(),
+    Schema = compose(include_for("x.ssl", "y.ssl")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [{["x", "ssl", "key", "RSAPrivateKey"], "PEM-BODY"}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = lookup(y, ssl, Config),
+    ?assertEqual({'RSAPrivateKey', <<"PEM-BODY">>},
+                 proplists:get_value(key, SslOpts)).
+
+key_translation_works_at_any_prefix_depth_test() ->
+    %% Robust against arbitrary include-site prefix depth, unlike the
+    %% original rabbit.schema translation which hardcoded `[_, _, K]'.
+    setup(),
+    Cases = [
+        {"deep.shovel.upstream.ssl", "rabbitmq_shovel.upstream.ssl",
+         ["deep", "shovel", "upstream", "ssl", "key", "RSAPrivateKey"]},
+        {"x.ssl", "y.ssl",
+         ["x", "ssl", "key", "RSAPrivateKey"]},
+        {"single", "single",
+         ["single", "key", "RSAPrivateKey"]}],
+    [begin
+         Schema = compose(include_for(Prefix, AppPrefix)),
+         SchemaTuple = cuttlefish_schema:strings(Schema),
+         Conf = [{ConfKey, "PEM-AT-DEPTH"}],
+         Config = cuttlefish_generator:map(SchemaTuple, Conf),
+         [_ | Steps] = string:split(AppPrefix, ".", all),
+         AppRoot = list_to_atom(hd(string:split(AppPrefix, ".", all))),
+         AppCfg = proplists:get_value(AppRoot, Config, []),
+         SslOpts = walk_proplist(Steps, AppCfg),
+         ?assertEqual({'RSAPrivateKey', <<"PEM-AT-DEPTH">>},
+                      proplists:get_value(key, SslOpts))
+     end || {Prefix, AppPrefix, ConfKey} <- Cases].
+
+%% --- ciphers ordering --------------------------------------------
+
+ciphers_translation_preserves_reverse_order_test() ->
+    setup(),
+    Schema = compose(include_for("x.ssl", "y.ssl")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [{["x", "ssl", "ciphers", "AAA"], "AAA"},
+            {["x", "ssl", "ciphers", "BBB"], "BBB"},
+            {["x", "ssl", "ciphers", "CCC"], "CCC"}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    Ciphers = proplists:get_value(ciphers, lookup(y, ssl, Config)),
+    ?assertEqual(3, length(Ciphers)),
+    ?assertEqual(["AAA", "BBB", "CCC"], lists:sort(Ciphers)).
+
+%% --- empty conf doesn't invent values ----------------------------
+
+empty_conf_does_not_invent_values_test() ->
+    setup(),
+    Schema = compose(include_for("x.ssl", "y.ssl")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Config = cuttlefish_generator:map(SchemaTuple, []),
+    YApp = proplists:get_value(y, Config, []),
+    SslOpts = proplists:get_value(ssl, YApp, []),
+    ?assertEqual(undefined, proplists:get_value(verify, SslOpts)),
+    ?assertEqual(undefined, proplists:get_value(versions, SslOpts)).
+
+%% --- password translation calls rabbit_cuttlefish stub -----------
+
+password_translation_exercises_rabbit_cuttlefish_helper_test() ->
+    setup(),
+    Schema = compose(include_for("x.ssl", "y.ssl")),
+    SchemaTuple = cuttlefish_schema:strings(Schema),
+    Conf = [{["x", "ssl", "password"], "plain-pw"}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    SslOpts = lookup(y, ssl, Config),
+    ?assertEqual(<<"plain-pw">>, proplists:get_value(password, SslOpts)).
+
+%% ==================================================================
+%% End-to-end embedded migration: real partial + multiple migrated
+%% schema excerpts loaded together through `cuttlefish_schema:strings/1'.
+%% Mirrors a non-trivial subset of the RabbitMQ tree to prove the
+%% migration works when several plugins all pull in the shared partial
+%% with different prefix pairs and a couple of consumer-specific
+%% overrides.
+%% ==================================================================
+
+embedded_rabbitmq_migration_end_to_end_test() ->
+    setup(),
+    Schemas = [
+        rabbit_validators_schema(),
+        rabbit_primary_ssl_excerpt(),
+        rabbit_definitions_tls_excerpt(),
+        auth_backend_http_excerpt(),
+        auth_backend_ldap_excerpt(),
+        trust_store_excerpt(),
+        peer_discovery_consul_excerpt()
+    ],
+    SchemaTuple = cuttlefish_schema:strings(Schemas),
+    ?assertMatch({_T, _M, _V}, SchemaTuple),
+
+    Conf = [
+        %% rabbit primary listener TLS
+        {["ssl_options", "verify"],     verify_peer},
+        {["ssl_options", "cacertfile"], "/etc/rabbitmq/ca.pem"},
+        {["ssl_options", "certfile"],   "/etc/rabbitmq/server.pem"},
+        {["ssl_options", "keyfile"],    "/etc/rabbitmq/server.key"},
+        {["ssl_options", "depth"],      2},
+        {["ssl_options", "versions", "tlsv1.3"], 'tlsv1.3'},
+
+        %% definitions HTTPS
+        {["definitions", "tls", "verify"], verify_none},
+        {["definitions", "tls", "cacertfile"], "/etc/rabbitmq/defs-ca.pem"},
+
+        %% auth_backend_http
+        {["auth_http", "ssl_options"], none},
+
+        %% auth_backend_ldap
+        {["auth_ldap", "ssl_options", "verify"], verify_peer},
+        {["auth_ldap", "ssl_options", "cacertfile"], "/etc/ldap/ca.pem"},
+
+        %% trust_store
+        {["trust_store", "ssl_options", "verify"], verify_peer},
+
+        %% peer_discovery_consul
+        {["cluster_formation", "consul", "ssl_options", "verify"], verify_peer},
+        {["cluster_formation", "consul", "ssl_options", "cacertfile"],
+         "/etc/rabbitmq/consul-ca.pem"}
+    ],
+
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+
+    %% rabbit primary
+    Primary = lookup(rabbit, ssl_options, Config),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Primary)),
+    ?assertEqual("/etc/rabbitmq/ca.pem",
+                 proplists:get_value(cacertfile, Primary)),
+    ?assertEqual(2, proplists:get_value(depth, Primary)),
+    ?assertEqual(['tlsv1.3'], proplists:get_value(versions, Primary)),
+
+    %% rabbit definitions
+    Defs = proplists:get_value(definitions,
+                                proplists:get_value(rabbit, Config)),
+    DefsSsl = proplists:get_value(ssl_options, Defs),
+    ?assertEqual(verify_none, proplists:get_value(verify, DefsSsl)),
+    ?assertEqual("/etc/rabbitmq/defs-ca.pem",
+                 proplists:get_value(cacertfile, DefsSsl)),
+
+    %% auth_backend_http: the `= none' shortcut disables TLS
+    AuthHttp = proplists:get_value(rabbitmq_auth_backend_http, Config),
+    ?assertEqual([], proplists:get_value(ssl_options, AuthHttp)),
+
+    %% auth_backend_ldap: sub-options present
+    AuthLdapSsl = lookup(rabbitmq_auth_backend_ldap, ssl_options, Config),
+    ?assertEqual(verify_peer, proplists:get_value(verify, AuthLdapSsl)),
+    ?assertEqual("/etc/ldap/ca.pem",
+                 proplists:get_value(cacertfile, AuthLdapSsl)),
+
+    %% trust_store
+    TrustSsl = lookup(rabbitmq_trust_store, ssl_options, Config),
+    ?assertEqual(verify_peer, proplists:get_value(verify, TrustSsl)),
+
+    %% peer_discovery_consul
+    ConsulSsl = walk_proplist(
+                  ["cluster_formation", "peer_discovery_consul",
+                   "ssl_options"],
+                  proplists:get_value(rabbit, Config, [])),
+    ?assertEqual(verify_peer, proplists:get_value(verify, ConsulSsl)),
+    ?assertEqual("/etc/rabbitmq/consul-ca.pem",
+                 proplists:get_value(cacertfile, ConsulSsl)).
+
+embedded_migration_provenance_is_visible_in_each_mapping_test() ->
+    setup(),
+    Schemas = [
+        rabbit_validators_schema(),
+        auth_backend_http_excerpt()
+    ],
+    {_T, Mappings, _V} = cuttlefish_schema:strings(Schemas),
+    Verify = find_mapping(
+        ["auth_http", "ssl_options", "verify"], Mappings),
+    [ProvLine | _] = cuttlefish_mapping:doc(Verify),
+    ?assertEqual("(from partial sample_app:rabbit_ssl_options)",
+                 ProvLine).
+
+%% --- embedded migrated schema excerpts ---------------------------
+
+%% The validators normally defined in rabbit.schema; the partial's
+%% mappings reference them by name.
+rabbit_validators_schema() ->
+    "{validator, \"pem_file\", \"must be a readable PEM file\","
+    "    fun(_) -> true end}.\n"
+    "{validator, \"file_accessible\", \"must be a readable file\","
+    "    fun(_) -> true end}.\n"
+    "{validator, \"byte\", \"must be in 0..255\","
+    "    fun(N) -> is_integer(N) andalso N >= 0 andalso N =< 255 end}.\n".
+
+%% Mirrors the migrated rabbit.schema primary ssl_options block
+%% (post-partial form).
+rabbit_primary_ssl_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"ssl_options\"},"
+    "  {app_prefix, \"rabbit.ssl_options\"},"
+    "  {disable_with, none}]}.\n".
+
+%% Mirrors the migrated definitions.tls context.
+rabbit_definitions_tls_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"definitions.tls\"},"
+    "  {app_prefix, \"rabbit.definitions.ssl_options\"}]}.\n"
+    %% definitions.tls in the real schema overrides the partial's
+    %% binary password translation with a string one.
+    "{translation, \"rabbit.definitions.ssl_options.password\","
+    "    fun(Conf) -> rabbit_cuttlefish:optionally_tagged_string("
+    "                    \"definitions.tls.password\", Conf) end}.\n".
+
+%% Mirrors the migrated rabbitmq_auth_backend_http schema's TLS block.
+auth_backend_http_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"auth_http.ssl_options\"},"
+    "  {app_prefix, \"rabbitmq_auth_backend_http.ssl_options\"},"
+    "  {disable_with, none}]}.\n".
+
+%% Mirrors the migrated rabbitmq_auth_backend_ldap schema's TLS block.
+auth_backend_ldap_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"auth_ldap.ssl_options\"},"
+    "  {app_prefix, \"rabbitmq_auth_backend_ldap.ssl_options\"},"
+    "  {disable_with, none}]}.\n".
+
+%% Mirrors the migrated rabbitmq_trust_store schema's TLS block.
+trust_store_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"trust_store.ssl_options\"},"
+    "  {app_prefix, \"rabbitmq_trust_store.ssl_options\"},"
+    "  {disable_with, none}]}.\n".
+
+%% Mirrors the migrated rabbitmq_peer_discovery_consul schema's TLS block.
+peer_discovery_consul_excerpt() ->
+    "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+    " [{prefix, \"cluster_formation.consul.ssl_options\"},"
+    "  {app_prefix,"
+    "   \"rabbit.cluster_formation.peer_discovery_consul.ssl_options\"},"
+    "  {disable_with, none}]}.\n".
+
+%% --- helpers ------------------------------------------------------
+
+setup() ->
+    add_fixture_path(),
+    ensure_rabbit_cuttlefish_loaded().
+
+add_fixture_path() ->
+    Ebin = fixture_ebin(),
+    ok = ensure_sample_app_file(Ebin),
+    true = filelib:is_dir(Ebin) orelse
+        erlang:error({fixture_ebin_missing, Ebin}),
+    code:add_pathz(Ebin),
+    ok.
+
+%% Write `sample_app.app` if absent; rebar3 .gitignore excludes
+%% `ebin/`, so the fixture .app file isn't carried in version control.
+ensure_sample_app_file(Ebin) ->
+    ok = filelib:ensure_dir(filename:join(Ebin, "marker")),
+    AppFile = filename:join(Ebin, "sample_app.app"),
+    case filelib:is_regular(AppFile) of
+        true  -> ok;
+        false ->
+            App = "{application, sample_app,\n"
+                  " [{description, \"Test fixture for cuttlefish partials\"},\n"
+                  "  {vsn, \"0.0.1\"},\n"
+                  "  {modules, []},\n"
+                  "  {registered, []},\n"
+                  "  {applications, [kernel, stdlib]},\n"
+                  "  {env, []}]}.\n",
+            ok = file:write_file(AppFile, App)
+    end.
+
+fixture_ebin() ->
+    %% Resolve from cuttlefish's lib_dir (always set during tests) up
+    %% 4 levels to the project root, then into the source-tree fixture.
+    %% Avoids depending on rebar3 copying test/fixtures into _build.
+    LibDir = code:lib_dir(cuttlefish),
+    Project = filename:absname(
+                filename:join([LibDir, "..", "..", "..", ".."])),
+    filename:join([Project, "test", "fixtures",
+                   "sample_app", "ebin"]).
+
+%% Compile + load a `rabbit_cuttlefish` stub purely in memory so
+%% rebar3 doesn't try to treat it as a project source. The partial's
+%% password translation calls this module; without it the test would
+%% crash when conf sets `<prefix>.password'.
+ensure_rabbit_cuttlefish_loaded() ->
+    case code:is_loaded(rabbit_cuttlefish) of
+        false ->
+            Forms = stub_forms(),
+            {ok, rabbit_cuttlefish, Beam} =
+                compile:forms(Forms, [return_errors]),
+            {module, rabbit_cuttlefish} =
+                code:load_binary(rabbit_cuttlefish, "<inline-stub>", Beam),
+            ok;
+        _ -> ok
+    end.
+
+stub_forms() ->
+    Source =
+        "-module(rabbit_cuttlefish).\n"
+        "-export([optionally_tagged_binary/2, optionally_tagged_string/2]).\n"
+        "optionally_tagged_binary(Key, Conf) ->\n"
+        "    case cuttlefish:conf_get(Key, Conf, undefined) of\n"
+        "        undefined            -> cuttlefish:unset();\n"
+        "        Bin when is_binary(Bin) -> Bin;\n"
+        "        Str when is_list(Str) -> list_to_binary(Str);\n"
+        "        {_, V} when is_binary(V) -> {encrypted, V};\n"
+        "        {_, V} when is_list(V) -> {encrypted, list_to_binary(V)}\n"
+        "    end.\n"
+        "optionally_tagged_string(Key, Conf) ->\n"
+        "    case cuttlefish:conf_get(Key, Conf, undefined) of\n"
+        "        undefined -> cuttlefish:unset();\n"
+        "        V -> V\n"
+        "    end.\n",
+    {ok, Tokens, _} = erl_scan:string(Source),
+    [parse_form(F) || F <- split_dots(Tokens, [], [])].
+
+split_dots([], [], Acc) -> lists:reverse(Acc);
+split_dots([{dot, _} = D | Rest], Cur, Acc) ->
+    split_dots(Rest, [], [lists:reverse([D | Cur]) | Acc]);
+split_dots([T | Rest], Cur, Acc) ->
+    split_dots(Rest, [T | Cur], Acc).
+
+parse_form(Tokens) ->
+    {ok, Form} = erl_parse:parse_form(Tokens),
+    Form.
+
+include_for(Prefix, AppPrefix) ->
+    lists:flatten(io_lib:format(
+        "{include_partial, {sample_app, \"rabbit_ssl_options\"},"
+        " [{prefix, ~tp}, {app_prefix, ~tp}]}.\n",
+        [Prefix, AppPrefix])).
+
+%% Compose into a single schema string so the consumer's inline
+%% override appears AFTER the include in the same parse stream and
+%% the standard "later wins" semantics apply.
+compose(Tail) when is_list(Tail) ->
+    [rabbit_validators_schema() ++ Tail].
+compose(A, B) ->
+    [rabbit_validators_schema() ++ A ++ B].
+compose(A, B, C, D) ->
+    [rabbit_validators_schema() ++ A ++ B ++ C ++ D].
+
+lookup(App, Key, Config) ->
+    proplists:get_value(Key, proplists:get_value(App, Config, []), []).
+
+walk_proplist([], V) -> V;
+walk_proplist([Seg | Rest], Cfg) ->
+    walk_proplist(Rest, proplists:get_value(list_to_atom(Seg), Cfg, [])).
+
+find_mapping(Var, Mappings) ->
+    case [M || M <- Mappings, cuttlefish_mapping:variable(M) =:= Var] of
+        [M] -> M;
+        [] -> erlang:error({mapping_not_found, Var})
+    end.

--- a/test/cuttlefish_partial_rabbit_tcp_listen_options_tests.erl
+++ b/test/cuttlefish_partial_rabbit_tcp_listen_options_tests.erl
@@ -1,0 +1,136 @@
+-module(cuttlefish_partial_rabbit_tcp_listen_options_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+single_include_with_realistic_conf_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"mqtt.tcp_listen_options\"},\n"
+        "     {app_prefix, \"rabbitmq_mqtt.tcp_listen_options\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["mqtt", "tcp_listen_options", "backlog"],     128},
+            {["mqtt", "tcp_listen_options", "nodelay"],     true},
+            {["mqtt", "tcp_listen_options", "port"],        1883},
+            {["mqtt", "tcp_listen_options", "linger", "on"],      true},
+            {["mqtt", "tcp_listen_options", "linger", "timeout"], 10}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    TcpOpts = lookup(rabbitmq_mqtt, tcp_listen_options, Config),
+    ?assertEqual(128,   proplists:get_value(backlog, TcpOpts)),
+    ?assertEqual(true,  proplists:get_value(nodelay, TcpOpts)),
+    ?assertEqual(1883,  proplists:get_value(port, TcpOpts)),
+    ?assertEqual({true, 10}, proplists:get_value(linger, TcpOpts)).
+
+linger_aggregation_uses_defaults_when_only_one_set_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"x.tcp\"},\n"
+        "     {app_prefix, \"y.tcp\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "tcp", "linger", "timeout"], 5}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    Linger = proplists:get_value(linger, lookup(y, tcp, Config)),
+    ?assertEqual({false, 5}, Linger).
+
+port_validator_rejects_out_of_range_value_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"x.tcp\"},\n"
+        "     {app_prefix, \"y.tcp\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "tcp", "port"], 70000}],
+    Result = cuttlefish_generator:map(SchemaTuple, Conf),
+    ?assertMatch({error, validation, _}, Result).
+
+disable_with_short_circuit_at_parent_test() ->
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, \"x.tcp\"},\n"
+        "     {app_prefix, \"y.tcp\"},\n"
+        "     {disable_with, none}]}.\n",
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x", "tcp"], none}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    ?assertEqual([], proplists:get_value(tcp, proplists:get_value(y, Config))).
+
+four_listener_contexts_in_one_schema_test() ->
+    add_fixture_path(),
+    Schema = lists:flatten([
+        include_for("rabbit.tcp_listen_options", "rabbit.tcp_listen_options"),
+        include_for("mqtt.tcp_listen_options", "rabbitmq_mqtt.tcp_listen_options"),
+        include_for("stomp.tcp_listen_options", "rabbitmq_stomp.tcp_listen_options"),
+        include_for("stream.tcp_listen_options", "rabbitmq_stream.tcp_listen_options")
+    ]),
+    SchemaTuple = cuttlefish_schema:strings([Schema]),
+    Conf = [{["rabbit", "tcp_listen_options", "port"], 5672},
+            {["mqtt",   "tcp_listen_options", "port"], 1883},
+            {["stomp",  "tcp_listen_options", "port"], 61613},
+            {["stream", "tcp_listen_options", "port"], 5552}],
+    Config = cuttlefish_generator:map(SchemaTuple, Conf),
+    ?assertEqual(5672,
+                 proplists:get_value(port,
+                                     lookup(rabbit, tcp_listen_options, Config))),
+    ?assertEqual(1883,
+                 proplists:get_value(port,
+                                     lookup(rabbitmq_mqtt, tcp_listen_options, Config))),
+    ?assertEqual(61613,
+                 proplists:get_value(port,
+                                     lookup(rabbitmq_stomp, tcp_listen_options, Config))),
+    ?assertEqual(5552,
+                 proplists:get_value(port,
+                                     lookup(rabbitmq_stream, tcp_listen_options, Config))).
+
+%% --- helpers ------------------------------------------------------
+
+include_for(Prefix, AppPrefix) ->
+    lists:flatten(io_lib:format(
+        "{include_partial, {sample_app, \"rabbit_tcp_listen_options\"},\n"
+        "    [{prefix, ~tp},\n"
+        "     {app_prefix, ~tp},\n"
+        "     {disable_with, none}]}.\n",
+        [Prefix, AppPrefix])).
+
+lookup(App, Key, Config) ->
+    proplists:get_value(Key, proplists:get_value(App, Config, []), []).
+
+add_fixture_path() ->
+    Ebin = fixture_ebin(),
+    ok = ensure_sample_app_file(Ebin),
+    true = filelib:is_dir(Ebin) orelse
+        erlang:error({fixture_ebin_missing, Ebin}),
+    code:add_pathz(Ebin),
+    ok.
+
+%% Write `sample_app.app` if absent; rebar3 .gitignore excludes
+%% `ebin/`, so the fixture .app file isn't carried in version control.
+ensure_sample_app_file(Ebin) ->
+    ok = filelib:ensure_dir(filename:join(Ebin, "marker")),
+    AppFile = filename:join(Ebin, "sample_app.app"),
+    case filelib:is_regular(AppFile) of
+        true  -> ok;
+        false ->
+            App = "{application, sample_app,\n"
+                  " [{description, \"Test fixture for cuttlefish partials\"},\n"
+                  "  {vsn, \"0.0.1\"},\n"
+                  "  {modules, []},\n"
+                  "  {registered, []},\n"
+                  "  {applications, [kernel, stdlib]},\n"
+                  "  {env, []}]}.\n",
+            ok = file:write_file(AppFile, App)
+    end.
+
+fixture_ebin() ->
+    %% Resolve from cuttlefish's lib_dir (always set during tests) up
+    %% 4 levels to the project root, then into the source-tree fixture.
+    %% Avoids depending on rebar3 copying test/fixtures into _build.
+    LibDir = code:lib_dir(cuttlefish),
+    Project = filename:absname(
+                filename:join([LibDir, "..", "..", "..", ".."])),
+    filename:join([Project, "test", "fixtures",
+                   "sample_app", "ebin"]).

--- a/test/cuttlefish_partial_tests.erl
+++ b/test/cuttlefish_partial_tests.erl
@@ -1,0 +1,565 @@
+-module(cuttlefish_partial_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+-define(BASE_OPTS,
+        [{prefix, "x.ssl_options"},
+         {app_prefix, "y_app.ssl_options"}]).
+
+%% --- rewrite/2 -----------------------------------------------------
+
+mapping_conf_and_app_keys_get_prefixed_test() ->
+    Term = {mapping, "verify", "verify", [{datatype, atom}]},
+    {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertMatch({mapping, "x.ssl_options.verify",
+                          "y_app.ssl_options.verify",
+                          [{datatype, atom}]},
+                 Out).
+
+mapping_with_fuzzy_segment_is_preserved_test() ->
+    Term = {mapping, "versions.$version", "versions", [{datatype, atom}]},
+    {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual({mapping, "x.ssl_options.versions.$version",
+                          "y_app.ssl_options.versions",
+                          [{datatype, atom}]},
+                 Out).
+
+mapping_opts_pass_through_unchanged_test() ->
+    Opts = [{datatype, integer}, {default, 5},
+            {validators, ["v"]}, {hidden, true},
+            {level, advanced}, {commented, 10},
+            {include_default, "name"},
+            {aliases, ["legacy.absolute.key"]}],
+    Term = {mapping, "n", "n", Opts},
+    {ok, [{mapping, _, _, Out}]} =
+        cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual(Opts, Out).
+
+aliases_are_not_prefix_rewritten_test() ->
+    Opts = [{aliases, ["legacy.absolute.key"]}],
+    Term = {mapping, "n", "n", Opts},
+    {ok, [{mapping, _, _, Out}]} =
+        cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual([["legacy.absolute.key"]],
+                 proplists:get_all_values(aliases, Out)).
+
+see_bare_entries_get_prefix_dotted_entries_do_not_test() ->
+    %% Both kinds get tokenized so downstream code (which expects
+    %% `[variable()]`) treats them uniformly.
+    Term = {mapping, "cacertfile", "cacertfile",
+            [{see, ["certfile", "absolute.elsewhere"]}]},
+    {ok, [{mapping, _, _, Out}]} =
+        cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual([{see, [["x", "ssl_options", "certfile"],
+                         ["absolute", "elsewhere"]]}],
+                 Out).
+
+validator_passes_through_unchanged_test() ->
+    Fun = fun(_) -> true end,
+    Term = {validator, "pem_file", "must be a PEM file", Fun},
+    {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual(Term, Out).
+
+partial_translation_emits_arity1_closure_with_bound_prefixes_test() ->
+    Term = {partial_translation, "versions",
+            fun(C, P, A) -> {C, P, A} end},
+    {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertMatch({translation, "y_app.ssl_options.versions", _}, Out),
+    {translation, _, Bound} = Out,
+    ?assertEqual({arity, 1}, erlang:fun_info(Bound, arity)),
+    ?assertEqual({fake_conf, "x.ssl_options", "y_app.ssl_options"},
+                 Bound(fake_conf)).
+
+partial_translation_with_bad_arity_returns_error_test() ->
+    Bad1 = {partial_translation, "v", fun(_) -> ok end},
+    Bad2 = {partial_translation, "v", fun(_, _) -> ok end},
+    Bad4 = {partial_translation, "v", fun(_, _, _, _) -> ok end},
+    ?assertMatch({error, {partial_translation_bad_arity, "v", 1}},
+                 cuttlefish_partial:rewrite([Bad1], ?BASE_OPTS)),
+    ?assertMatch({error, {partial_translation_bad_arity, "v", 2}},
+                 cuttlefish_partial:rewrite([Bad2], ?BASE_OPTS)),
+    ?assertMatch({error, {partial_translation_bad_arity, "v", 4}},
+                 cuttlefish_partial:rewrite([Bad4], ?BASE_OPTS)).
+
+%% --- exclude semantics --------------------------------------------
+
+exclude_drops_an_exact_bare_name_test() ->
+    Terms = [{mapping, "verify", "verify", []},
+             {mapping, "cacertfile", "cacertfile", []}],
+    Opts = ?BASE_OPTS ++ [{exclude, ["verify"]}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(1, length(Out)),
+    [{mapping, "x.ssl_options.cacertfile", _, _}] = Out.
+
+exclude_section_drops_a_mapping_family_test() ->
+    Terms = [{mapping, "versions.$version", "versions", []},
+             {mapping, "verify", "verify", []}],
+    Opts = ?BASE_OPTS ++ [{exclude, ["versions"]}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(1, length(Out)),
+    [{mapping, "x.ssl_options.verify", _, _}] = Out.
+
+exclude_section_drops_matching_translation_test() ->
+    Terms = [{partial_translation, "versions",
+              fun(_, _, _) -> [] end},
+             {partial_translation, "ciphers",
+              fun(_, _, _) -> [] end}],
+    Opts = ?BASE_OPTS ++ [{exclude, ["versions"]}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(1, length(Out)),
+    [{translation, "y_app.ssl_options.ciphers", _}] = Out.
+
+exclude_first_segment_match_is_exact_not_substring_test() ->
+    %% "versions" must not drop "versions_extra".
+    Terms = [{mapping, "versions_extra", "versions_extra", []},
+             {mapping, "versions.$v", "versions", []}],
+    Opts = ?BASE_OPTS ++ [{exclude, ["versions"]}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(1, length(Out)),
+    [{mapping, "x.ssl_options.versions_extra", _, _}] = Out.
+
+exclude_empty_list_is_a_noop_test() ->
+    Terms = [{mapping, "verify", "verify", []}],
+    Opts = ?BASE_OPTS ++ [{exclude, []}],
+    {ok, [_]} = cuttlefish_partial:rewrite(Terms, Opts).
+
+%% --- overrides ----------------------------------------------------
+
+overrides_replace_a_mapping_field_test() ->
+    Terms = [{mapping, "cacertfile", "cacertfile",
+              [{datatype, string}, {validators, ["pem_file"]}]}],
+    Opts = ?BASE_OPTS ++ [{overrides, [{"cacertfile",
+                                         {validators, ["file_accessible"]}}]}],
+    {ok, [{mapping, _, _, OutOpts}]} =
+        cuttlefish_partial:rewrite(Terms, Opts),
+    %% Override-supplied {validators, _} wins over the partial's default.
+    ?assertEqual(["file_accessible"], proplists:get_value(validators, OutOpts)),
+    %% Other opts from the partial survive unchanged.
+    ?assertEqual(string, proplists:get_value(datatype, OutOpts)).
+
+overrides_only_touch_named_mappings_test() ->
+    Terms = [{mapping, "cacertfile", "cacertfile", [{validators, ["pem_file"]}]},
+             {mapping, "certfile", "certfile",   [{validators, ["pem_file"]}]}],
+    Opts = ?BASE_OPTS ++ [{overrides, [{"cacertfile",
+                                         {validators, ["file_accessible"]}}]}],
+    {ok, [{mapping, _, _, O1}, {mapping, _, _, O2}]} =
+        cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(["file_accessible"], proplists:get_value(validators, O1)),
+    ?assertEqual(["pem_file"], proplists:get_value(validators, O2)).
+
+overrides_can_add_a_new_opt_test() ->
+    Terms = [{mapping, "verify", "verify", [{datatype, atom}]}],
+    Opts = ?BASE_OPTS ++ [{overrides, [{"verify", {default, verify_peer}}]}],
+    {ok, [{mapping, _, _, OutOpts}]} =
+        cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(verify_peer, proplists:get_value(default, OutOpts)).
+
+overrides_with_bad_shape_is_rejected_test() ->
+    Bad = ?BASE_OPTS ++ [{overrides, [{"verify", not_a_tuple}]}],
+    ?assertMatch({error, {partial_unknown_include_opt, {overrides, _}}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+%% --- disable_with -------------------------------------------------
+
+disable_with_adds_guard_mapping_and_translation_test() ->
+    Terms = [{mapping, "verify", "verify", [{datatype, atom}]}],
+    Opts = ?BASE_OPTS ++ [{disable_with, none}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    ?assertEqual(3, length(Out)),
+    %% Partial mapping survives.
+    ?assert(lists:any(
+        fun({mapping, "x.ssl_options.verify", _, _}) -> true;
+           (_) -> false
+        end, Out)),
+    %% Guard mapping uses the bare prefix as its conf key.
+    [Guard] = [M || {mapping, "x.ssl_options", _, _} = M <- Out],
+    ?assertMatch({mapping, _, "y_app.ssl_options",
+                  [{datatype, {enum, [none]}}]}, Guard),
+    %% Guard translation accepts the configured atom and produces [].
+    [{translation, _, GuardFun}] = [T || {translation, _, _} = T <- Out],
+    ?assertEqual([], GuardFun([{["x", "ssl_options"], none}])).
+
+disable_with_rejects_other_values_via_translation_test() ->
+    Opts = ?BASE_OPTS ++ [{disable_with, none}],
+    {ok, Out} = cuttlefish_partial:rewrite([], Opts),
+    [{translation, _, F}] = [T || {translation, _, _} = T <- Out],
+    %% A non-matching value triggers `cuttlefish:invalid`, which throws.
+    ?assertThrow({invalid, _},
+                 F([{["x", "ssl_options"], something_else}])).
+
+disable_with_non_atom_is_rejected_test() ->
+    Bad = ?BASE_OPTS ++ [{disable_with, "string-not-atom"}],
+    ?assertMatch({error, {partial_unknown_include_opt,
+                          {disable_with, "string-not-atom"}}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+disable_with_guard_returns_unset_when_parent_absent_test() ->
+    %% Defence-in-depth: cuttlefish_generator drops translations whose
+    %% target has no contributing mapping value today, so this branch
+    %% is unreachable through `cuttlefish_generator:map/2'. If that
+    %% behaviour ever changes the translation still degrades gracefully.
+    Opts = ?BASE_OPTS ++ [{disable_with, none}],
+    {ok, Out} = cuttlefish_partial:rewrite([], Opts),
+    [{translation, _, F}] = [T || {translation, _, _} = T <- Out],
+    ?assertThrow(unset, F([])).
+
+disable_with_combined_with_overrides_test() ->
+    %% disable_with appends the guard after the rewritten body, so
+    %% overrides on the body and the guard coexist without
+    %% interfering.
+    Terms = [{mapping, "verify", "verify",
+              [{datatype, atom}, {default, verify_none}]}],
+    Opts = ?BASE_OPTS
+        ++ [{overrides, [{"verify", {default, verify_peer}}]},
+            {disable_with, none}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    %% 1 partial mapping + 1 guard mapping + 1 guard translation.
+    ?assertEqual(3, length(Out)),
+    [{mapping, "x.ssl_options.verify", _, OutOpts}] =
+        [M || {mapping, "x.ssl_options.verify", _, _} = M <- Out],
+    ?assertEqual(verify_peer, proplists:get_value(default, OutOpts)).
+
+%% --- include-opt validation ---------------------------------------
+
+missing_prefix_is_rejected_test() ->
+    Bad = [{app_prefix, "y"}],
+    ?assertMatch({error, {partial_missing_prefix, sample_app, "example"}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+missing_app_prefix_is_rejected_test() ->
+    Bad = [{prefix, "x"}],
+    ?assertMatch({error, {partial_missing_app_prefix, sample_app, "example"}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+empty_prefix_is_rejected_test() ->
+    Bad = [{prefix, ""}, {app_prefix, "y"}],
+    ?assertMatch({error, {partial_empty_prefix, sample_app, "example"}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+empty_app_prefix_is_rejected_test() ->
+    Bad = [{prefix, "x"}, {app_prefix, ""}],
+    ?assertMatch({error, {partial_empty_prefix, sample_app, "example"}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+unknown_include_opt_is_rejected_test() ->
+    Bad = [{predix, "x"}, {app_prefix, "y"}],
+    ?assertMatch({error, {partial_unknown_include_opt, {predix, "x"}}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+opts_must_be_a_list_test() ->
+    ?assertMatch({error, {partial_unknown_include_opt, not_a_list}},
+                 cuttlefish_partial:load(sample_app, "example", not_a_list)).
+
+%% --- loader (filesystem + app) ------------------------------------
+
+load_unknown_app_returns_error_test() ->
+    Result = cuttlefish_partial:load(definitely_no_such_app_xyz, "example",
+                                      ?BASE_OPTS),
+    ?assertMatch({error, {partial_app_not_loadable, definitely_no_such_app_xyz, _}},
+                 Result).
+
+load_missing_partial_returns_file_not_found_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "no_such_partial",
+                                      ?BASE_OPTS),
+    ?assertMatch({error, {partial_file_not_found, sample_app,
+                          "no_such_partial", _}}, Result).
+
+load_partial_with_plain_translation_returns_helpful_error_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "with_translation",
+                                      ?BASE_OPTS),
+    ?assertEqual({error, {partial_unsupported_term, translation}}, Result).
+
+load_partial_with_nested_include_is_rejected_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "with_nested_include",
+                                      ?BASE_OPTS),
+    ?assertEqual({error, {partial_include_in_partial, sample_app,
+                          "with_nested_include"}}, Result).
+
+load_partial_with_bad_arity_is_rejected_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "with_bad_arity",
+                                      ?BASE_OPTS),
+    ?assertEqual({error, {partial_translation_bad_arity, "versions", 2}},
+                 Result).
+
+load_partial_with_unsupported_term_is_rejected_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "with_unsupported",
+                                      ?BASE_OPTS),
+    ?assertEqual({error, {partial_unsupported_term, config}}, Result).
+
+%% --- exclude/overrides name validation ---------------------------
+
+exclude_with_typo_is_rejected_test() ->
+    %% A misspelled exclude name (`versiosns`) currently no-ops
+    %% silently without validation. The pre-flight catches it.
+    add_fixture_path(),
+    Bad = ?BASE_OPTS ++ [{exclude, ["versiosns"]}],
+    Result = cuttlefish_partial:load(sample_app, "example", Bad),
+    ?assertMatch({error, {partial_exclude_unmatched, sample_app, "example",
+                          ["versiosns"]}}, Result).
+
+exclude_lists_all_unmatched_names_at_once_test() ->
+    add_fixture_path(),
+    Bad = ?BASE_OPTS ++ [{exclude, ["typo1", "verify", "typo2"]}],
+    Result = cuttlefish_partial:load(sample_app, "example", Bad),
+    %% Valid `verify` survives; both typos surface in one error.
+    ?assertMatch({error, {partial_exclude_unmatched, sample_app, "example",
+                          ["typo1", "typo2"]}}, Result).
+
+exclude_section_match_counts_as_matched_test() ->
+    %% `versions` (the section name) matches the `versions.$version`
+    %% mapping via first-segment match, so validation accepts it
+    %% even though there is no exact-named mapping called `versions`.
+    add_fixture_path(),
+    Opts = ?BASE_OPTS ++ [{exclude, ["versions"]}],
+    {ok, _} = cuttlefish_partial:load(sample_app, "example", Opts).
+
+overrides_with_typo_is_rejected_test() ->
+    add_fixture_path(),
+    Bad = ?BASE_OPTS ++ [{overrides, [{"certfle",
+                                        {validators, ["file_accessible"]}}]}],
+    Result = cuttlefish_partial:load(sample_app, "example", Bad),
+    ?assertMatch({error, {partial_overrides_unmatched, sample_app, "example",
+                          ["certfle"]}}, Result).
+
+overrides_targeting_a_translation_only_is_rejected_test() ->
+    %% `versions` matches the partial_translation but NOT a mapping;
+    %% overrides apply to mappings only, so this is rejected.
+    add_fixture_path(),
+    Bad = ?BASE_OPTS ++ [{overrides, [{"versions", {default, []}}]}],
+    Result = cuttlefish_partial:load(sample_app, "example", Bad),
+    ?assertMatch({error, {partial_overrides_unmatched, _, _, ["versions"]}},
+                 Result).
+
+xlate_partial_exclude_unmatched_test() ->
+    Msg = ?XLATE({partial_exclude_unmatched, sample_app, "example",
+                  ["typo1", "typo2"]}),
+    ?assert(string:find(Msg, "sample_app") =/= nomatch),
+    ?assert(string:find(Msg, "'typo1'") =/= nomatch),
+    ?assert(string:find(Msg, "'typo2'") =/= nomatch).
+
+xlate_partial_overrides_unmatched_test() ->
+    Msg = ?XLATE({partial_overrides_unmatched, sample_app, "example",
+                  ["certfle"]}),
+    ?assert(string:find(Msg, "'certfle'") =/= nomatch),
+    ?assert(string:find(Msg, "overrides") =/= nomatch).
+
+load_empty_partial_succeeds_test() ->
+    add_fixture_path(),
+    ?assertEqual({ok, []},
+                 cuttlefish_partial:load(sample_app, "empty", ?BASE_OPTS)).
+
+load_partial_with_syntax_error_returns_error_test() ->
+    add_fixture_path(),
+    Result = cuttlefish_partial:load(sample_app, "syntax_error", ?BASE_OPTS),
+    ?assertMatch({error, {partial_parse_error, sample_app, "syntax_error",
+                          {erl_parse, _, _}}}, Result).
+
+exclude_empty_entry_is_rejected_test() ->
+    Bad = ?BASE_OPTS ++ [{exclude, [""]}],
+    ?assertMatch({error, {partial_unknown_include_opt, {exclude, [""]}}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+exclude_non_string_entry_is_rejected_test() ->
+    Bad = ?BASE_OPTS ++ [{exclude, [some_atom]}],
+    ?assertMatch({error, {partial_unknown_include_opt, {exclude, [some_atom]}}},
+                 cuttlefish_partial:load(sample_app, "example", Bad)).
+
+exclude_can_match_a_dotted_bare_key_exactly_test() ->
+    %% Unusual but supported: a partial with a dotted bare key can be
+    %% excluded by its full bare name.
+    Terms = [{mapping, "a.b", "a.b", []},
+             {mapping, "c", "c", []}],
+    Opts = ?BASE_OPTS ++ [{exclude, ["a.b"]}],
+    {ok, Out} = cuttlefish_partial:rewrite(Terms, Opts),
+    Bares = [strip_prefix(K) || {mapping, K, _, _} <- Out],
+    ?assertEqual(["c"], Bares).
+
+%% Helper for the test above.
+strip_prefix("x.ssl_options." ++ Rest) -> Rest;
+strip_prefix(Other) -> Other.
+
+load_happy_path_returns_rewritten_terms_test() ->
+    add_fixture_path(),
+    {ok, Terms} = cuttlefish_partial:load(sample_app, "example", ?BASE_OPTS),
+    %% The fixture has 4 mappings + 1 partial_translation = 5 terms.
+    ?assertEqual(5, length(Terms)),
+    Mappings = [T || {mapping, _, _, _} = T <- Terms],
+    Translations = [T || {translation, _, _} = T <- Terms],
+    ?assertEqual(4, length(Mappings)),
+    ?assertEqual(1, length(Translations)),
+    %% Every emitted conf and app key starts with the include prefix.
+    lists:foreach(
+      fun({mapping, ConfKey, AppKey, _}) ->
+              ?assert(lists:prefix("x.ssl_options.", ConfKey)),
+              ?assert(lists:prefix("y_app.ssl_options.", AppKey))
+      end, Mappings).
+
+%% --- bind_translation/3 -------------------------------------------
+
+bind_translation_produces_arity1_test() ->
+    Bound = cuttlefish_partial:bind_translation(
+              fun(_, _, _) -> ok end, "p", "ap"),
+    ?assertEqual({arity, 1}, erlang:fun_info(Bound, arity)).
+
+bind_translation_captures_only_the_prefixes_test() ->
+    %% A trivial smoke check that the closure forwards what the caller
+    %% provides and nothing more.
+    Bound = cuttlefish_partial:bind_translation(
+              fun(Conf, P, A) -> {Conf, P, A} end, "p", "ap"),
+    ?assertEqual({some_conf, "p", "ap"}, Bound(some_conf)).
+
+%% --- is_partial_filename/1 ----------------------------------------
+
+is_partial_filename_true_for_partial_test() ->
+    ?assert(cuttlefish_partial:is_partial_filename("foo.partial")),
+    ?assert(cuttlefish_partial:is_partial_filename("/path/to/foo.partial")).
+
+is_partial_filename_false_for_other_extensions_test() ->
+    ?assertNot(cuttlefish_partial:is_partial_filename("foo.schema")),
+    ?assertNot(cuttlefish_partial:is_partial_filename("foo")),
+    ?assertNot(cuttlefish_partial:is_partial_filename("foo.partial.bak")).
+
+%% --- xlate ---------------------------------------------------------
+
+xlate_partial_app_not_loadable_test() ->
+    ?assertEqual("Could not load OTP application 'no_such' to resolve "
+                 "partial: bad_reason",
+                 ?XLATE({partial_app_not_loadable, no_such, bad_reason})).
+
+xlate_partial_app_not_loadable_missing_app_file_hints_at_code_path_test() ->
+    %% application:load/1 returns this exact tuple when the .app file
+    %% is not on the code path. The hint nudges the user toward the
+    %% actual cause rather than dumping the raw `{"no such file...",_}`.
+    Msg = ?XLATE({partial_app_not_loadable, rabbit,
+                  {"no such file or directory", "rabbit.app"}}),
+    ?assert(string:find(Msg, "rabbit") =/= nomatch),
+    ?assert(string:find(Msg, "code path") =/= nomatch),
+    ?assert(string:find(Msg, "code:add_pathz") =/= nomatch).
+
+xlate_partial_app_no_priv_dir_test() ->
+    ?assertEqual("OTP application 'noprivapp' has no priv dir; "
+                 "cannot resolve partial",
+                 ?XLATE({partial_app_no_priv_dir, noprivapp})).
+
+xlate_partial_file_not_found_test() ->
+    ?assertEqual("Partial 'example' not found for app 'sample_app' at: "
+                 "/tmp/x.partial",
+                 ?XLATE({partial_file_not_found, sample_app, "example",
+                         "/tmp/x.partial"})).
+
+xlate_partial_unsupported_translation_points_at_partial_translation_test() ->
+    Msg = ?XLATE({partial_unsupported_term, translation}),
+    ?assert(string:find(Msg, "partial_translation") =/= nomatch),
+    ?assert(string:find(Msg, "{translation,") =/= nomatch).
+
+xlate_partial_unsupported_other_term_test() ->
+    Msg = ?XLATE({partial_unsupported_term, config}),
+    ?assert(string:find(Msg, "config") =/= nomatch).
+
+xlate_partial_translation_bad_arity_test() ->
+    ?assertEqual("Partial translation 'versions' has arity 2; must be 3 "
+                 "(Conf, ConfPrefix, AppPrefix)",
+                 ?XLATE({partial_translation_bad_arity, "versions", 2})).
+
+xlate_partial_missing_prefix_test() ->
+    ?assertEqual("Include of partial 'rabbit:ssl_options' is missing "
+                 "the required {prefix, _} argument",
+                 ?XLATE({partial_missing_prefix, rabbit, "ssl_options"})).
+
+xlate_partial_missing_app_prefix_test() ->
+    ?assertEqual("Include of partial 'rabbit:ssl_options' is missing "
+                 "the required {app_prefix, _} argument",
+                 ?XLATE({partial_missing_app_prefix, rabbit, "ssl_options"})).
+
+xlate_partial_empty_prefix_test() ->
+    ?assertEqual("Include of partial 'rabbit:ssl_options' has an empty "
+                 "prefix or app_prefix",
+                 ?XLATE({partial_empty_prefix, rabbit, "ssl_options"})).
+
+xlate_partial_unknown_include_opt_test() ->
+    Msg = ?XLATE({partial_unknown_include_opt, {predix, "x"}}),
+    ?assert(string:find(Msg, "Unknown include_partial option") =/= nomatch),
+    ?assert(string:find(Msg, "predix") =/= nomatch).
+
+xlate_partial_file_read_error_includes_reason_test() ->
+    Msg = ?XLATE({partial_file_read_error, rabbit, "ssl_options",
+                  "/etc/ssl_options.partial", eacces}),
+    ?assert(string:find(Msg, "rabbit") =/= nomatch),
+    ?assert(string:find(Msg, "ssl_options") =/= nomatch),
+    ?assert(string:find(Msg, "eacces") =/= nomatch).
+
+xlate_partial_include_in_partial_test() ->
+    ?assertEqual("Partial 'rabbit:ssl_options' contains an "
+                 "include_partial term; partials cannot nest",
+                 ?XLATE({partial_include_in_partial, rabbit, "ssl_options"})).
+
+xlate_partial_file_too_large_test() ->
+    Msg = ?XLATE({partial_file_too_large, {"/tmp/x.partial", 9999999, 8388608}}),
+    ?assert(string:find(Msg, "size 9999999") =/= nomatch),
+    ?assert(string:find(Msg, "8388608") =/= nomatch).
+
+xlate_partial_file_invalid_unicode_test() ->
+    Msg = ?XLATE({partial_file_invalid_unicode, "/tmp/x.partial"}),
+    ?assert(string:find(Msg, "not valid UTF-8") =/= nomatch).
+
+xlate_partial_bad_directive_includes_offending_term_test() ->
+    Msg = ?XLATE({partial_bad_directive, "wrong-shape"}),
+    ?assert(string:find(Msg, "Malformed") =/= nomatch),
+    ?assert(string:find(Msg, "wrong-shape") =/= nomatch).
+
+xlate_partial_parse_error_names_partial_test() ->
+    %% The error message must point at the offending partial, not
+    %% just a line number with no file context.
+    Msg = ?XLATE({partial_parse_error, rabbit, "ssl_options",
+                  {erl_parse, 12, "syntax error before: ')'"}}),
+    ?assert(string:find(Msg, "rabbit") =/= nomatch),
+    ?assert(string:find(Msg, "ssl_options") =/= nomatch),
+    ?assert(string:find(Msg, "line 12") =/= nomatch).
+
+%% --- helpers ------------------------------------------------------
+
+%% Add the test fixtures' sample_app ebin/ to the code path so
+%% `application:load/1` and `code:priv_dir/1` can resolve it.
+%% Tests run from the project root; `test/fixtures` resolves there.
+add_fixture_path() ->
+    Ebin = fixture_ebin(),
+    ok = ensure_sample_app_file(Ebin),
+    true = filelib:is_dir(Ebin) orelse
+        erlang:error({fixture_ebin_missing, Ebin}),
+    code:add_pathz(Ebin),
+    ok.
+
+%% Write `sample_app.app` if absent; rebar3 .gitignore excludes
+%% `ebin/`, so the fixture .app file isn't carried in version control.
+ensure_sample_app_file(Ebin) ->
+    ok = filelib:ensure_dir(filename:join(Ebin, "marker")),
+    AppFile = filename:join(Ebin, "sample_app.app"),
+    case filelib:is_regular(AppFile) of
+        true  -> ok;
+        false ->
+            App = "{application, sample_app,\n"
+                  " [{description, \"Test fixture for cuttlefish partials\"},\n"
+                  "  {vsn, \"0.0.1\"},\n"
+                  "  {modules, []},\n"
+                  "  {registered, []},\n"
+                  "  {applications, [kernel, stdlib]},\n"
+                  "  {env, []}]}.\n",
+            ok = file:write_file(AppFile, App)
+    end.
+
+fixture_ebin() ->
+    %% Resolve from cuttlefish's lib_dir (always set during tests) up
+    %% 4 levels to the project root, then into the source-tree fixture.
+    %% Avoids depending on rebar3 copying test/fixtures into _build.
+    LibDir = code:lib_dir(cuttlefish),
+    Project = filename:absname(
+                filename:join([LibDir, "..", "..", "..", ".."])),
+    filename:join([Project, "test", "fixtures",
+                   "sample_app", "ebin"]).

--- a/test/cuttlefish_validator_refs_tests.erl
+++ b/test/cuttlefish_validator_refs_tests.erl
@@ -1,0 +1,57 @@
+-module(cuttlefish_validator_refs_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+missing_validator_is_rejected_at_schema_load_test() ->
+    %% A mapping that references an undefined validator fails at
+    %% schema-load time rather than waiting for validation phase.
+    Schema = "{mapping, \"x\", \"app.x\","
+             " [{datatype, integer}, {validators, [\"no_such_validator\"]}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist,
+                  [{error, {validator_not_defined, "x", "no_such_validator"}}]},
+                 Result).
+
+defined_validator_passes_test() ->
+    Schema =
+        "{validator, \"positive\", \"must be positive\","
+        " fun(N) -> N > 0 end}.\n"
+        "{mapping, \"x\", \"app.x\","
+        " [{datatype, integer}, {validators, [\"positive\"]}]}.\n",
+    ?assertMatch({_, [_], [_]}, cuttlefish_schema:strings([Schema])).
+
+validator_defined_in_sibling_schema_passes_test() ->
+    %% Multiple-schema merge: the validator is defined in one schema,
+    %% referenced in another. Pre-flight runs after the merge so both
+    %% are visible.
+    Validator =
+        "{validator, \"positive\", \"must be positive\","
+        " fun(N) -> N > 0 end}.\n",
+    Consumer =
+        "{mapping, \"x\", \"app.x\","
+        " [{datatype, integer}, {validators, [\"positive\"]}]}.\n",
+    ?assertMatch({_, [_], [_]},
+                 cuttlefish_schema:strings([Validator, Consumer])).
+
+multiple_missing_validators_are_all_reported_test() ->
+    Schema = "{mapping, \"x\", \"app.x\","
+             " [{datatype, integer},"
+             "  {validators, [\"missing_a\", \"missing_b\"]}]}.\n",
+    {errorlist, Errors} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual(2, length(Errors)),
+    ?assert(lists:any(
+        fun({error, {validator_not_defined, "x", "missing_a"}}) -> true;
+           (_) -> false
+        end, Errors)),
+    ?assert(lists:any(
+        fun({error, {validator_not_defined, "x", "missing_b"}}) -> true;
+           (_) -> false
+        end, Errors)).
+
+xlate_validator_not_defined_is_actionable_test() ->
+    Msg = ?XLATE({validator_not_defined, "auth_http.ssl_options.cacertfile",
+                  "pem_file"}),
+    ?assert(string:find(Msg, "auth_http.ssl_options.cacertfile") =/= nomatch),
+    ?assert(string:find(Msg, "pem_file") =/= nomatch).

--- a/test/fixtures/sample_app/priv/schema/empty.partial
+++ b/test/fixtures/sample_app/priv/schema/empty.partial
@@ -1,0 +1,3 @@
+%% Fixture: nothing but comments and whitespace.
+%% A partial may be empty.
+

--- a/test/fixtures/sample_app/priv/schema/example.partial
+++ b/test/fixtures/sample_app/priv/schema/example.partial
@@ -1,0 +1,30 @@
+%% Fixture: a small but representative partial.
+%%
+%% Include with, e.g.:
+%%
+%%   {include_partial, {sample_app, "example"},
+%%       [{prefix,     "x.ssl_options"},
+%%        {app_prefix, "x_app.ssl_options"}]}.
+
+{mapping, "verify", "verify",
+    [{datatype, {enum, [verify_peer, verify_none]}},
+     {default, verify_none}]}.
+
+{mapping, "cacertfile", "cacertfile",
+    [{datatype, string},
+     {see, ["certfile"]}]}.
+
+{mapping, "certfile", "certfile",
+    [{datatype, string}]}.
+
+{mapping, "versions.$version", "versions",
+    [{datatype, atom}]}.
+
+{partial_translation, "versions",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(
+                ConfPrefix ++ ".versions", Conf) of
+            []  -> cuttlefish:unset();
+            Set -> [V || {_, V} <- Set]
+        end
+    end}.

--- a/test/fixtures/sample_app/priv/schema/rabbit_ssl_options.partial
+++ b/test/fixtures/sample_app/priv/schema/rabbit_ssl_options.partial
@@ -1,0 +1,140 @@
+%% Reusable TLS options block for RabbitMQ plugin schemas.
+%%
+%% Include with:
+%%
+%%   {include_partial, {rabbit, "ssl_options"},
+%%       [{prefix,     "auth_http.ssl_options"},
+%%        {app_prefix, "rabbitmq_auth_backend_http.ssl_options"}]}.
+%%
+%% The partial declares the mappings and bound translations that every
+%% TLS-using plugin needs. Consumers can override individual mappings
+%% with `merge`, replace translations by redeclaring them after the
+%% include, drop unwanted sections with `{exclude, [...]}`, or add
+%% plugin-specific mappings inline. The `pem_file` and `byte`
+%% validators are defined in `rabbit.schema'.
+
+{mapping, "verify", "verify",
+    [{datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "fail_if_no_peer_cert", "fail_if_no_peer_cert",
+    [{datatype, boolean}]}.
+
+{mapping, "cacertfile", "cacertfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "certfile", "certfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "cert", "cert",
+    [{datatype, string}]}.
+
+{partial_translation, "cert",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        list_to_binary(cuttlefish:conf_get(ConfPrefix ++ ".cert", Conf))
+    end}.
+
+{mapping, "client_renegotiation", "client_renegotiation",
+    [{datatype, boolean}]}.
+
+{mapping, "honor_cipher_order", "honor_cipher_order",
+    [{datatype, boolean}]}.
+
+{mapping, "honor_ecc_order", "honor_ecc_order",
+    [{datatype, boolean}]}.
+
+%% `sni' and `hostname_verification' are intentionally NOT in this
+%% partial: real consumers use different app-key shapes (e.g.
+%% `rabbitmq_auth_backend_http.ssl_hostname_verification' at the
+%% application root, not under `.ssl_options.'). Consumers that need
+%% them declare their own mapping inline after the include.
+
+{mapping, "log_level", "log_level",
+    [{datatype, {enum, [emergency, alert, critical, error,
+                        warning, notice, info, debug]}}]}.
+
+{mapping, "crl_check", "crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "depth", "depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "dh", "dh",
+    [{datatype, string}]}.
+
+{partial_translation, "dh",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        list_to_binary(cuttlefish:conf_get(ConfPrefix ++ ".dh", Conf))
+    end}.
+
+{mapping, "dhfile", "dhfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "key.RSAPrivateKey", "key",
+    [{datatype, string}]}.
+
+{mapping, "key.DSAPrivateKey", "key",
+    [{datatype, string}]}.
+
+{mapping, "key.PrivateKeyInfo", "key",
+    [{datatype, string}]}.
+
+%% Use `lists:last/1' so the partial works at any prefix depth,
+%% unlike the original rabbit.schema translation which hardcodes a
+%% 2-segment conf prefix via `[_, _, Key]'.
+{partial_translation, "key",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(ConfPrefix ++ ".key", Conf) of
+            [{Path, Val} | _] when is_list(Path) ->
+                {list_to_atom(lists:last(Path)), list_to_binary(Val)};
+            _ ->
+                cuttlefish:unset()
+        end
+    end}.
+
+{mapping, "keyfile", "keyfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "log_alert", "log_alert",
+    [{datatype, boolean}]}.
+
+{mapping, "password", "password",
+    [{datatype, [tagged_binary, binary]}]}.
+
+{partial_translation, "password",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        rabbit_cuttlefish:optionally_tagged_binary(
+            ConfPrefix ++ ".password", Conf)
+    end}.
+
+{mapping, "psk_identity", "psk_identity",
+    [{datatype, string}]}.
+
+{mapping, "reuse_sessions", "reuse_sessions",
+    [{datatype, boolean}]}.
+
+{mapping, "secure_renegotiate", "secure_renegotiate",
+    [{datatype, boolean}]}.
+
+{mapping, "versions.$version", "versions",
+    [{datatype, atom}]}.
+
+{partial_translation, "versions",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(
+                 ConfPrefix ++ ".versions", Conf) of
+            []       -> cuttlefish:unset();
+            Settings -> [V || {_, V} <- Settings]
+        end
+    end}.
+
+{mapping, "ciphers.$cipher", "ciphers",
+    [{datatype, string}]}.
+
+{partial_translation, "ciphers",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        case cuttlefish_variable:filter_by_prefix(
+                 ConfPrefix ++ ".ciphers", Conf) of
+            []       -> cuttlefish:unset();
+            Settings -> lists:reverse([V || {_, V} <- Settings])
+        end
+    end}.

--- a/test/fixtures/sample_app/priv/schema/rabbit_tcp_listen_options.partial
+++ b/test/fixtures/sample_app/priv/schema/rabbit_tcp_listen_options.partial
@@ -1,0 +1,47 @@
+%% Mimic of rabbit.schema's tcp_listen_options.* block (the one shared
+%% by rabbit/mqtt/stomp/stream). Used by the cuttlefish-side fidelity
+%% test to exercise the partial mechanism against a real-world TCP
+%% socket-options shape without requiring a RabbitMQ checkout.
+
+{validator, "port", "must be in range 0..65535",
+    fun(N) -> is_integer(N) andalso N >= 0 andalso N =< 65535 end}.
+
+{validator, "non_negative_integer", "must be >= 0",
+    fun(N) -> is_integer(N) andalso N >= 0 end}.
+
+{mapping, "backlog", "backlog",             [{datatype, integer}]}.
+{mapping, "nodelay", "nodelay",             [{datatype, boolean}]}.
+{mapping, "buffer",  "buffer",              [{datatype, integer}]}.
+{mapping, "delay_send", "delay_send",       [{datatype, boolean}]}.
+{mapping, "dontroute", "dontroute",         [{datatype, boolean}]}.
+{mapping, "exit_on_close", "exit_on_close", [{datatype, boolean}]}.
+{mapping, "fd", "fd",                       [{datatype, integer}]}.
+{mapping, "high_msgq_watermark", "high_msgq_watermark",
+    [{datatype, integer}]}.
+{mapping, "high_watermark", "high_watermark", [{datatype, integer}]}.
+{mapping, "keepalive", "keepalive",         [{datatype, boolean}]}.
+{mapping, "low_msgq_watermark", "low_msgq_watermark",
+    [{datatype, integer}]}.
+{mapping, "low_watermark", "low_watermark", [{datatype, integer}]}.
+{mapping, "port", "port",
+    [{datatype, integer}, {validators, ["port"]}]}.
+{mapping, "priority", "priority",           [{datatype, integer}]}.
+{mapping, "recbuf", "recbuf",               [{datatype, integer}]}.
+{mapping, "send_timeout", "send_timeout",   [{datatype, integer}]}.
+{mapping, "send_timeout_close", "send_timeout_close",
+    [{datatype, boolean}]}.
+{mapping, "sndbuf", "sndbuf",               [{datatype, integer}]}.
+{mapping, "tos", "tos",                     [{datatype, integer}]}.
+
+%% Two mappings that target the same app key, aggregated by the
+%% translation into Erlang's `{Bool, Timeout}' linger tuple.
+{mapping, "linger.on", "linger",            [{datatype, boolean}]}.
+{mapping, "linger.timeout", "linger",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
+
+{partial_translation, "linger",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        On      = cuttlefish:conf_get(ConfPrefix ++ ".linger.on", Conf, false),
+        Timeout = cuttlefish:conf_get(ConfPrefix ++ ".linger.timeout", Conf, 0),
+        {On, Timeout}
+    end}.

--- a/test/fixtures/sample_app/priv/schema/syntax_error.partial
+++ b/test/fixtures/sample_app/priv/schema/syntax_error.partial
@@ -1,0 +1,5 @@
+%% Fixture: deliberately malformed Erlang.
+
+{mapping, "verify", "verify", [
+    {datatype, atom},
+}.

--- a/test/fixtures/sample_app/priv/schema/with_bad_arity.partial
+++ b/test/fixtures/sample_app/priv/schema/with_bad_arity.partial
@@ -1,0 +1,6 @@
+%% Fixture: an arity-2 partial translation is rejected.
+
+{mapping, "verify", "verify", [{datatype, atom}]}.
+
+{partial_translation, "versions",
+    fun(_Conf, _ConfPrefix) -> [] end}.

--- a/test/fixtures/sample_app/priv/schema/with_doc.partial
+++ b/test/fixtures/sample_app/priv/schema/with_doc.partial
@@ -1,0 +1,8 @@
+%% Fixture for testing `@doc' and `@see' annotation flow-through.
+
+%% @doc Sets the verify mode.
+%% @doc Multiple lines are joined.
+%% @see certfile
+{mapping, "verify", "verify", [{datatype, atom}]}.
+
+{mapping, "certfile", "certfile", [{datatype, string}]}.

--- a/test/fixtures/sample_app/priv/schema/with_nested_include.partial
+++ b/test/fixtures/sample_app/priv/schema/with_nested_include.partial
@@ -1,0 +1,6 @@
+%% Fixture: nesting is rejected.
+
+{mapping, "verify", "verify", [{datatype, atom}]}.
+
+{include_partial, {sample_app, "example"},
+    [{prefix, "y"}, {app_prefix, "y"}]}.

--- a/test/fixtures/sample_app/priv/schema/with_translation.partial
+++ b/test/fixtures/sample_app/priv/schema/with_translation.partial
@@ -1,0 +1,6 @@
+%% Fixture: a plain `translation` form is rejected with the
+%% "use partial_translation instead" error.
+
+{mapping, "verify", "verify", [{datatype, atom}]}.
+
+{translation, "versions", fun(_Conf) -> [] end}.

--- a/test/fixtures/sample_app/priv/schema/with_unsupported.partial
+++ b/test/fixtures/sample_app/priv/schema/with_unsupported.partial
@@ -1,0 +1,3 @@
+%% Fixture: a non-mapping/validator/partial_translation tuple is rejected.
+
+{config, "value"}.


### PR DESCRIPTION
## What are Schema Partials?

A partial is a reusable mapping and translation block that allows highly repetitive blocks (think `*.ssl_options.*` key groups in multiple places in RabbitMQ) to be
extracted and customized in their final schema files.

Partials use a separate file extension, `.partial`, to make the intent clear. Partial files are assumed to be stored next to the "full" schema files, e.g. in `<App>/priv/schema/<Name>.partial`.

The main schema file then includes the partials like so:

```erl
{include_partial, {App, "name"}, [
  {prefix, ConfPrefix},
  {app_prefix, AppPrefix}
]}.
```

`cuttlefish_partial:load/3` resolves the file via `code:priv_dir(App)`, expands it at parse time, and rewrites each bare conf and app key with the include's prefixes; subsequent stages then see normal mappings and translations.

Some more optional features supported by partials: `exclude`, `disable_with` and `overrides`. All are motivated by the more advanced cases where partial can be used to extract duplication in RabbitMQ schemas.

`{exclude, [Name]}` drops a mapping by bare
name or first-segment section match.

`{disable_with, Atom}` emits the very common `= none` guard pair so consumers do not repeat that block.

Names in `exclude` and `overrides` are checked against the partial's contents; a typo produces a visible
`partial_exclude_unmatched` or `partial_overrides_unmatched` error rather than silently no-opping.

Translations inside a partial use a distinct translation fn option, `{partial_translation, "Name", fun(Conf, ConfPrefix, AppPrefix) -> _ end}`. Regular `{translation, ...}` inside a partial is rejected with a message pointing at `partial_translation`.
The Cuttlefish loader binds the prefixes.

For simplicity, partials cannot be nested.


## Partial Loading from Different Erlang Apps

A partial can be loaded from the same app or another one, allowing plugins-based
systems to define a few partials that plugins can reuse, which is the end goal
with the `*.ssl_options.*` key groups in RabbitMQ.


## Real World Duplication Reduction in RabbitMQ

A research migration using this Cuttlefish version removes 1,186 lines of duplicated schema and adds 80 lines of include directives plus 225 lines for the two shared partials, which produces a net saving of 881 repetitive lines around `*.ssl_options.*` key groups.

This PR includes a comparable set of integration tests that use a number of schema files
virtually identical to the real RabbitMQ schema ones.