### PR TITLE
New data types, minor improvements to validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## Unreleased
+## Unreleased (3.9.0)
+
+**Enhancements:**
+
+ - `allow_infinity` shortcut atom in integer/float/bytesize/duration constraint lists: accepts the atom `infinity` (also the matching string a conf file produces) alongside the numeric form
+ - Range constraints on `bytesize`: `{bytesize, [{min, N}, {max, N}, {gt, N}, {lt, N}]}`, plus the `non_negative` and `positive` shortcuts
+ - Range constraints on durations: `{duration, Unit, [Constraints]}` mirroring the integer/float syntax, with the bound expressed in the declared unit
+ - `{validator, Fun}` and `{validator, Name}` entries inside an integer/float/bytesize/duration constraint list. Constraints run left-to-right; first failure wins
+ - 5-tuple validator form: `{validator, Name, Desc, Fun, Options}`. Options accept `{aliases, [Name]}` (rename a validator without breaking call sites) and `{deprecated, Since, Hint}` (emit a single warn line on first use per load cycle)
+ - Built-in validators `"port"`, `"byte"`, `"valid_regex"` delegating to the matching 3.8.0 datatype. Injected on demand only when referenced; a user definition with the same name wins silently
+ - Built-in marker validator `"uri"` (no-op by design) so a schema that historically declared a no-op `"uri"` validator inline can drop the declaration without rewriting call sites
+ - New `cuttlefish_diff:render_normalised/1,2` library function that produces a deterministic, sorted, printable form of `cuttlefish_generator:map/2` output for line-diffing migration runs. Options: `{skip_funs, bool}`, `{atom_quoting, strict | loose}`
+
+## 3.8.0
 
 **Enhancements:**
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -337,13 +337,27 @@ Three named aliases cover common ranges:
 - `byte` = `{integer, [{min, 0}, {max, 255}]}`
 - `percent` = `{percent, integer}` (0-100)
 
-For settings that accept the atom `infinity` in addition to a numeric value, compose with the existing datatype-list mechanism — first match wins:
+For settings that accept the atom `infinity` in addition to a numeric value, add `allow_infinity` to the constraint list. Both the atom `infinity` and the string a conf file produces for it parse to the atom `infinity`; other inputs go through the usual numeric pipeline.
+
+```erlang
+{datatype, {integer, [non_negative, allow_infinity]}}
+{datatype, {integer, [{min, 1}, {max, 65535}, allow_infinity]}}
+```
+
+The older datatype-list form continues to work and is equivalent for back-compat purposes:
 
 ```erlang
 {datatype, [{atom, infinity}, {integer, non_negative}]}
 ```
 
-Out-of-range values surface as `{error, {range_violation, {Value, FailedConstraint}}}`.
+A constraint list also accepts validator entries — either by name (looked up in the loaded validator set) or by anonymous function. Constraints fire left-to-right, first failure wins:
+
+```erlang
+{datatype, {integer, [{min, 1}, {max, 65535}, {validator, "power_of_two"}]}}
+{datatype, {integer, [{min, 1}, {validator, fun(N) -> N rem 4 =:= 0 end}]}}
+```
+
+Out-of-range values surface as `{error, {range_violation, {Value, FailedConstraint}}}`. Validator failures surface as `{error, {constraint_validator_failed, Value}}`.
 
 ### `string`
 
@@ -460,6 +474,14 @@ Parses a byte size with optional unit suffix (`KB`, `MB`, `GB`). Case-insensitiv
 object.size.maximum = 50MB
 ```
 
+Bounds are written against the parsed byte count:
+
+```erlang
+{datatype, {bytesize, [{min, 1}, {max, 1073741824}]}}
+{datatype, {bytesize, non_negative}}
+{datatype, {bytesize, [non_negative, allow_infinity]}}
+```
+
 ### `{duration, Unit}`
 
 Parses a duration string (e.g. `5s`, `2h30m`). Erlang type: `integer()` (in the specified unit).
@@ -472,6 +494,13 @@ Units: `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days
 
 ```
 handoff.timeout = 30s
+```
+
+Bounds are expressed in the declared unit:
+
+```erlang
+{datatype, {duration, ms, [{min, 0}, {max, 60000}]}}
+{datatype, {duration, s, [non_negative, allow_infinity]}}
 ```
 
 ### `{percent, integer}` and `{percent, float}`
@@ -584,6 +613,36 @@ Reference validators by name in a mapping's `validators` list:
 ```
 
 The validator function receives the typed value (after datatype conversion). Return `true` to pass, `false` to fail. On failure, cuttlefish reports the validator description as the error message.
+
+### Aliases and deprecation hints
+
+A validator may carry an optional 5th argument: a proplist with `{aliases, [Name]}` and/or `{deprecated, Since, Hint}`. Both are independent.
+
+```erlang
+{validator, "new_name", "must be positive",
+            fun(N) -> N > 0 end,
+            [{aliases, ["old_name"]},
+             {deprecated, "3.9.0", "use {integer, positive} datatype"}]}.
+```
+
+`aliases` lets a renamed validator answer to its old name(s) so call sites can migrate at their own pace. The same alias may not appear on two different validators or shadow another validator's canonical name.
+
+`deprecated` causes cuttlefish to emit a single `warn`-level log line the first time the validator runs in a given load cycle. Repeat uses are silenced. The hint should point the schema author at the replacement form.
+
+### Built-in validators
+
+Cuttlefish ships a small set of built-in validators that delegate to the matching datatype:
+
+| Name | Equivalent |
+|---|---|
+| `"byte"` | `byte` datatype (0..255) |
+| `"port"` | `port` datatype (0..65535) |
+| `"valid_regex"` | `regex` datatype (rejects empty patterns and patterns prone to catastrophic backtracking) |
+| `"uri"` | no-op marker (accepts any string) |
+
+These are injected on demand only when a mapping actually references them. A user-defined validator with the same name wins silently — the local predicate is intentional, and the deprecation hint on the builtin (which fires only when the builtin is what runs) is the channel for nudging the migration. The intent is to let a schema drop its in-tree definition of one of these names without rewriting call sites; the migration to the native datatype form (`{datatype, port}` etc.) is then a separate, gradual cleanup.
+
+`"uri"` is a marker validator by design — it accepts any string, so call sites that historically used a no-op `"uri"` predicate with template-style values (`https://{{node}}/...`) keep working when their local definition is deleted. Use the `uri` datatype when you want structural validation.
 
 ---
 
@@ -739,3 +798,26 @@ Understanding the pipeline helps when debugging unexpected behavior.
 8. **Run translations** - Translation functions produce the final Erlang values. Direct 1:1 mappings (and `{collect, Type}` mappings) are applied here as well.
 
 The output is a `[{AppName, [{Key, Value}]}]` proplist suitable for use as `app.config`.
+
+---
+
+## Diffing Two Pipeline Outputs
+
+When migrating a schema, the safest check is "the generated `app.config` is the same for any valid input". `cuttlefish_diff:render_normalised/1,2` takes the output of `cuttlefish_generator:map/2` and returns a deterministic, sorted, printable form suitable for line-diffing:
+
+```erlang
+{ok, Before} = cuttlefish_generator:map(OldSchemas, Conf),
+{ok, After}  = cuttlefish_generator:map(NewSchemas, Conf),
+A = cuttlefish_diff:render_normalised(Before, [{skip_funs, true}]),
+B = cuttlefish_diff:render_normalised(After,  [{skip_funs, true}]),
+%% feed A and B to your diff tool of choice
+```
+
+Two equivalent configs that differ only by internal key order produce the same string; any real difference shows up as a localised line-level change. The second argument is an options proplist:
+
+| Option | Default | Effect |
+|---|---|---|
+| `{skip_funs, bool}` | `true` | Render every function as the stable placeholder `#Fun<>`. With `false`, use Erlang's `~p` form, which may differ between runs |
+| `{atom_quoting, strict \| loose}` | `loose` | `strict` quotes atoms via `~p` (e.g. `'with-dashes'`); `loose` emits the bare name |
+
+The library function is intended to be called from CI scripts and migration verification harnesses. There is no CLI subcommand in 3.9.0.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,16 @@
 # `cuttlefish` release process
 
-Here are the commands to run when releasing `cuttlefish` `3.8.0`:
+Here are the commands to run when releasing `cuttlefish` `3.9.0`:
 
 ```
-git checkout -b cuttlefish-3.8.0
-sed -i.bak 's/3\.7\.0/3.8.0/' src/cuttlefish.app.src
-github_changelog_generator --future-release v3.8.0 --user Kyorai --project cuttlefish --token "$GITHUB_API_TOKEN"
-git commit -a -m 'v3.8.0'
-git push -u origin cuttlefish-3.8.0
+git checkout -b cuttlefish-3.9.0
+sed -i.bak 's/3\.8\.0/3.9.0/' src/cuttlefish.app.src
+github_changelog_generator --future-release v3.9.0 --user Kyorai --project cuttlefish --token "$GITHUB_API_TOKEN"
+git commit -a -m 'v3.9.0'
+git push -u origin cuttlefish-3.9.0
 ```
 
-* Open pull request for the `cuttlefish-3.8.0` branch
+* Open pull request for the `cuttlefish-3.9.0` branch
 * Ensure CI runs successfully for the PR
 * Merge PR
 
@@ -18,10 +18,10 @@ git push -u origin cuttlefish-3.8.0
 git checkout main
 git pull origin main
 git remote prune origin
-git branch -d cuttlefish-3.8.0
-git tag --annotate --sign --local-user=GPGKEYID --message='cuttlefish 3.8.0' 'v3.8.0'
+git branch -d cuttlefish-3.9.0
+git tag --annotate --sign --local-user=GPGKEYID --message='cuttlefish 3.9.0' 'v3.9.0'
 git push --tags
-gh release create v3.8.0 --verify-tag --title 'v3.8.0' --latest --generate-notes
+gh release create v3.9.0 --verify-tag --title 'v3.9.0' --latest --generate-notes
 ```
 
 **NOTE:** ensure that the correct version is displayed when `rebar3 hex publish` is run:

--- a/src/cuttlefish.app.src
+++ b/src/cuttlefish.app.src
@@ -1,6 +1,6 @@
 {application,cuttlefish,
              [{description,"cuttlefish configuration abstraction"},
-              {vsn,"3.8.0"},
+              {vsn,"3.9.0"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {env,[]},

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -39,7 +39,9 @@
                     fqdn |
                     domain_socket |
                     {duration, cuttlefish_duration:time_unit() } |
+                    {duration, cuttlefish_duration:time_unit(), [numeric_constraint()] | numeric_shortcut()} |
                     bytesize |
+                    {bytesize, [numeric_constraint()] | numeric_shortcut()} |
                     {percent, integer} |
                     {percent, float} |
                     percent |
@@ -58,9 +60,13 @@
                             | {max, number()}
                             | {gt,  number()}
                             | {lt,  number()}
-                            | numeric_shortcut().
+                            | numeric_shortcut()
+                            | allow_infinity
+                            | {validator, validator_fun()}
+                            | {validator, string()}.
 
 -type numeric_shortcut() :: non_negative | positive.
+-type validator_fun() :: fun((term()) -> boolean()).
 -type extended() :: { integer, integer() } |
                     { string, string() } |
                     { binary, binary() } |
@@ -86,7 +92,9 @@
          is_valid_list/1,
          from_string/2,
          to_string/2,
-         extended_from/1
+         extended_from/1,
+         constraint_validator_refs/1,
+         resolve_constraint_validators/2
 ]).
 
 -spec is_supported(any()) -> boolean().
@@ -112,6 +120,12 @@ is_supported({duration, m}) -> true;
 is_supported({duration, s}) -> true;
 is_supported({duration, ms}) -> true;
 is_supported(bytesize) -> true;
+is_supported({bytesize, Constraints}) ->
+    valid_constraints(Constraints, integer);
+is_supported({duration, Unit, Constraints})
+  when Unit =:= f; Unit =:= w; Unit =:= d; Unit =:= h;
+       Unit =:= m; Unit =:= s; Unit =:= ms ->
+    valid_constraints(Constraints, integer);
 is_supported({percent, integer}) -> true;
 is_supported({percent, float}) -> true;
 is_supported(percent) -> true;
@@ -213,10 +227,23 @@ to_string(Integer, integer) when is_list(Integer) -> Integer;
 to_string(Value, port) -> to_string(Value, integer);
 to_string(Value, byte) -> to_string(Value, integer);
 to_string(Value, percent) -> to_string(Value, {percent, integer});
+%% The `allow_infinity' shortcut leaves the atom `infinity' unchanged
+%% on the conversion path; here the printable form is the literal
+%% characters. These clauses must precede the generic constraint
+%% clauses below — those would match first and recurse into the
+%% integer/float clauses, which reject the atom.
+to_string(infinity, {integer, _}) -> "infinity";
+to_string(infinity, {float, _}) -> "infinity";
+to_string(infinity, {bytesize, _}) -> "infinity";
+to_string(infinity, {duration, _, _}) -> "infinity";
 to_string(Value, {integer, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
     to_string(Value, integer);
 to_string(Value, {float, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
     to_string(Value, float);
+to_string(Value, {bytesize, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    to_string(Value, bytesize);
+to_string(Value, {duration, Unit, Constraints}) when is_list(Constraints); is_atom(Constraints) ->
+    to_string(Value, {duration, Unit});
 
 to_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> IP ++ ":" ++ integer_to_list(Port);
 to_string(IPString, ip) when is_list(IPString) -> IPString;
@@ -333,10 +360,20 @@ from_string(Value, percent) ->
     from_string(Value, {percent, integer});
 
 from_string(Value, {integer, Constraints}) ->
-    apply_numeric_constraints(from_string(Value, integer), Constraints, integer);
+    case maybe_infinity(Value, Constraints) of
+        {ok, Inf}      -> Inf;
+        not_applicable ->
+            apply_numeric_constraints(from_string(Value, integer),
+                                      Constraints, integer)
+    end;
 
 from_string(Value, {float, Constraints}) ->
-    apply_numeric_constraints(from_string(Value, float), Constraints, float);
+    case maybe_infinity(Value, Constraints) of
+        {ok, Inf}      -> Inf;
+        not_applicable ->
+            apply_numeric_constraints(from_string(Value, float),
+                                      Constraints, float)
+    end;
 
 from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
 from_string(String, ip) when is_list(String) ->
@@ -395,8 +432,24 @@ from_string(String, domain_socket) when is_list(String) ->
 from_string(Duration, {duration, _}) when is_integer(Duration) -> Duration;
 from_string(Duration, {duration, Unit}) when is_list(Duration) -> cuttlefish_duration:parse(Duration, Unit);
 
+from_string(Value, {duration, Unit, Constraints}) ->
+    case maybe_infinity(Value, Constraints) of
+        {ok, Inf}      -> Inf;
+        not_applicable ->
+            apply_numeric_constraints(from_string(Value, {duration, Unit}),
+                                      Constraints, integer)
+    end;
+
 from_string(Bytesize, bytesize) when is_integer(Bytesize) -> Bytesize;
 from_string(Bytesize, bytesize) when is_list(Bytesize) -> cuttlefish_bytesize:parse(Bytesize);
+
+from_string(Value, {bytesize, Constraints}) ->
+    case maybe_infinity(Value, Constraints) of
+        {ok, Inf}      -> Inf;
+        not_applicable ->
+            apply_numeric_constraints(from_string(Value, bytesize),
+                                      Constraints, integer)
+    end;
 
 from_string(String, string) when is_list(String) -> String;
 
@@ -631,20 +684,45 @@ validate_uri_schemes(Schemes) when is_list(Schemes) ->
 
 valid_constraints(non_negative, _BaseType) -> true;
 valid_constraints(positive,     _BaseType) -> true;
+valid_constraints(allow_infinity, _BaseType) -> true;
 valid_constraints(Constraints, BaseType) when is_list(Constraints) ->
     lists:all(fun(C) -> valid_constraint(C, BaseType) end, Constraints);
 valid_constraints(_, _) -> false.
 
 valid_constraint(non_negative, _) -> true;
 valid_constraint(positive,     _) -> true;
+valid_constraint(allow_infinity, _) -> true;
 valid_constraint({min, N}, T) -> is_bound(N, T);
 valid_constraint({max, N}, T) -> is_bound(N, T);
 valid_constraint({gt,  N}, T) -> is_bound(N, T);
 valid_constraint({lt,  N}, T) -> is_bound(N, T);
+valid_constraint({validator, Fun}, _) when is_function(Fun, 1) -> true;
+valid_constraint({validator, Name}, _) when is_list(Name) -> true;
 valid_constraint(_, _) -> false.
 
 is_bound(N, integer) -> is_integer(N);
 is_bound(N, float)   -> is_number(N).
+
+%% `allow_infinity' in the constraint list lets the atom `infinity'
+%% bypass numeric parsing and bound checks. Conf-file values arrive
+%% as the matching string; both forms are accepted. When the bypass
+%% fires the remaining constraints are skipped: the atom is meant to
+%% be a valid value regardless of bounds.
+maybe_infinity(Value, Constraints) ->
+    case allows_infinity(Constraints) andalso is_infinity_value(Value) of
+        true  -> {ok, infinity};
+        false -> not_applicable
+    end.
+
+allows_infinity(allow_infinity) -> true;
+allows_infinity(Constraints) when is_list(Constraints) ->
+    lists:member(allow_infinity, Constraints);
+allows_infinity(_) -> false.
+
+is_infinity_value(infinity) -> true;
+is_infinity_value("infinity") -> true;
+is_infinity_value(<<"infinity">>) -> true;
+is_infinity_value(_) -> false.
 
 apply_numeric_constraints({error, _} = E, _Constraints, _BaseType) ->
     E;
@@ -655,21 +733,102 @@ expand_constraints(non_negative, integer) -> [{min, 0}];
 expand_constraints(non_negative, float)   -> [{min, +0.0}];
 expand_constraints(positive, integer) -> [{min, 1}];
 expand_constraints(positive, float)   -> [{gt, +0.0}];
+%% `allow_infinity' is consumed by `maybe_infinity'; drop it here so
+%% the numeric path doesn't try to evaluate it as a bound.
+expand_constraints(allow_infinity, _) -> [];
 expand_constraints(Constraints, BaseType) when is_list(Constraints) ->
     lists:flatmap(fun(C) -> expand_constraints(C, BaseType) end, Constraints);
 expand_constraints(C, _BaseType) -> [C].
 
 check_constraints(Value, []) -> Value;
+check_constraints(Value, [{validator, Fun} | Rest]) when is_function(Fun, 1) ->
+    case run_validator(Fun, Value) of
+        true  -> check_constraints(Value, Rest);
+        false -> {error, {constraint_validator_failed, Value}}
+    end;
+%% A string-form name here means name resolution did not run; surface
+%% the orphan rather than silently treating it as a pass.
+check_constraints(_Value, [{validator, Name} | _]) when is_list(Name) ->
+    {error, {constraint_validator_unresolved, Name}};
 check_constraints(Value, [Constraint | Rest]) ->
     case satisfies(Value, Constraint) of
         true  -> check_constraints(Value, Rest);
         false -> {error, {range_violation, {Value, Constraint}}}
     end.
 
+%% Validator funs may throw; treat any exception as a failure rather
+%% than letting it escape into the surrounding pipeline.
+run_validator(Fun, Value) ->
+    try Fun(Value) of
+        true -> true;
+        _    -> false
+    catch
+        _:_ -> false
+    end.
+
 satisfies(V, {min, N}) -> V >= N;
 satisfies(V, {max, N}) -> V =< N;
 satisfies(V, {gt,  N}) -> V >  N;
 satisfies(V, {lt,  N}) -> V <  N.
+
+%% Collects every string-form name referenced as `{validator, Name}'
+%% inside any constraint list in `DT'. Returned sorted and unique so
+%% schema-time pre-flight checks can run against a stable set —
+%% catching a typo at schema load rather than at config generation.
+-spec constraint_validator_refs(datatype() | [datatype()]) -> [string()].
+constraint_validator_refs(DT) ->
+    lists:usort(collect_refs(DT)).
+
+collect_refs(L) when is_list(L) ->
+    lists:flatmap(fun collect_refs/1, L);
+collect_refs({integer, Cs}) -> collect_constraint_refs(Cs);
+collect_refs({float, Cs})   -> collect_constraint_refs(Cs);
+collect_refs({bytesize, Cs}) -> collect_constraint_refs(Cs);
+collect_refs({duration, _Unit, Cs}) -> collect_constraint_refs(Cs);
+collect_refs({list, Inner}) -> collect_refs(Inner);
+collect_refs(_) -> [].
+
+collect_constraint_refs(L) when is_list(L) ->
+    [N || {validator, N} <- L, is_list(N)];
+collect_constraint_refs(_) -> [].
+
+%% Walks the datatype expression and replaces each `{validator, Name}'
+%% inside a constraint list with the resolved `{validator, Fun}'.
+%% Names that don't resolve are left in place; the runtime constraint
+%% pipeline surfaces them as `{constraint_validator_unresolved, Name}'.
+%% Refs are expected to have been validated up front, so an unresolved
+%% name reaching the runtime indicates a genuinely orphaned reference.
+-spec resolve_constraint_validators(
+        datatype() | [datatype()],
+        fun((string()) -> {ok, validator_fun()} | not_found)) ->
+    datatype() | [datatype()].
+resolve_constraint_validators(DT, Lookup) ->
+    walk_resolve(DT, Lookup).
+
+walk_resolve(L, Lookup) when is_list(L) ->
+    [walk_resolve(E, Lookup) || E <- L];
+walk_resolve({integer, Cs}, Lookup) ->
+    {integer, resolve_cs(Cs, Lookup)};
+walk_resolve({float, Cs}, Lookup) ->
+    {float, resolve_cs(Cs, Lookup)};
+walk_resolve({bytesize, Cs}, Lookup) ->
+    {bytesize, resolve_cs(Cs, Lookup)};
+walk_resolve({duration, Unit, Cs}, Lookup) ->
+    {duration, Unit, resolve_cs(Cs, Lookup)};
+walk_resolve({list, Inner}, Lookup) ->
+    {list, walk_resolve(Inner, Lookup)};
+walk_resolve(Other, _Lookup) -> Other.
+
+resolve_cs(Cs, Lookup) when is_list(Cs) ->
+    [resolve_c(C, Lookup) || C <- Cs];
+resolve_cs(C, _Lookup) -> C.
+
+resolve_c({validator, Name}, Lookup) when is_list(Name) ->
+    case Lookup(Name) of
+        {ok, Fun} when is_function(Fun, 1) -> {validator, Fun};
+        _ -> {validator, Name}
+    end;
+resolve_c(C, _Lookup) -> C.
 
 -ifdef(TEST).
 

--- a/src/cuttlefish_diff.erl
+++ b/src/cuttlefish_diff.erl
@@ -1,0 +1,171 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_diff: deterministic rendering of generated app.config
+%% proplists for line-diffing two pipeline outputs.
+%%
+%% Copyright (c) 2026 Broadcom. All Rights Reserved. The term Broadcom
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(cuttlefish_diff).
+
+-export([render_normalised/1, render_normalised/2]).
+
+-type option() :: {skip_funs, boolean()}
+                | {atom_quoting, strict | loose}.
+-type options() :: [option()].
+-export_type([options/0]).
+
+%% @doc Produces a deterministic, sorted, printable string for the
+%% output of `cuttlefish_generator:map/2'. Two outputs that should
+%% be equivalent under the schema produce identical strings; any
+%% real difference shows up as a localised line-level diff.
+-spec render_normalised([proplists:property()]) -> iolist().
+render_normalised(Config) ->
+    render_normalised(Config, []).
+
+-spec render_normalised([proplists:property()], options()) -> iolist().
+render_normalised(Config, Options) ->
+    Sorted = canonicalise(Config),
+    [render_top(Entry, Options) || Entry <- Sorted].
+
+%% Top-level entries are `{App, Settings}'. Each app section header
+%% goes on its own line for easy diffing, followed by indented key
+%% lines, then a blank line as a separator.
+render_top({App, Settings}, Options) when is_atom(App), is_list(Settings) ->
+    [render_atom(App, Options), " =>\n",
+     [["  ", render_pair(Pair, Options), "\n"] || Pair <- Settings],
+     "\n"];
+render_top(Other, Options) ->
+    %% A non-`{App, Settings}' tuple at the top level is unusual but
+    %% not an error; render it the same way a nested value would be.
+    [render_term(Other, Options), "\n"].
+
+render_pair({Key, Value}, Options) ->
+    [render_term(Key, Options), " = ", render_term(Value, Options)];
+render_pair(Other, Options) ->
+    render_term(Other, Options).
+
+%% Funs/pids/ports/refs have no stable structural form between runs.
+%% Under default `{skip_funs, true}', funs collapse to `#Fun<>'; with
+%% `{skip_funs, false}' the `~p' form (e.g. `#Fun<m:f/n>') gives a
+%% little more detail at the cost of being less stable across nodes.
+%% Pids/ports/refs always reduce to `#Opaque<>' — their printed form
+%% embeds runtime identifiers and is never useful for diffing.
+render_term(V, _) when is_atom(V), V =:= true -> "true";
+render_term(V, _) when is_atom(V), V =:= false -> "false";
+render_term(V, _) when is_atom(V), V =:= undefined -> "undefined";
+render_term(V, Options) when is_atom(V) -> render_atom(V, Options);
+render_term(V, _) when is_integer(V) -> integer_to_list(V);
+render_term(V, _) when is_float(V)   -> float_to_list(V, [{decimals, 12}, compact]);
+render_term(V, _Options) when is_binary(V) ->
+    %% Distinguish a binary from a string of the same characters.
+    ["<<", render_string(unicode:characters_to_list(V)), ">>"];
+render_term(V, Options) when is_function(V) ->
+    case proplists:get_value(skip_funs, Options, true) of
+        true  -> "#Fun<>";
+        false -> io_lib:format("~p", [V])
+    end;
+render_term(V, _) when is_pid(V); is_port(V); is_reference(V) ->
+    "#Opaque<>";
+render_term([], _) -> "[]";
+render_term(V, Options) when is_list(V) ->
+    case io_lib:printable_unicode_list(V) of
+        true ->
+            ["\"", render_string(V), "\""];
+        false ->
+            ["[",
+             string:join([lists:flatten(render_term(E, Options)) || E <- V], ", "),
+             "]"]
+    end;
+render_term(V, Options) when is_tuple(V) ->
+    Elements = tuple_to_list(V),
+    ["{",
+     string:join([lists:flatten(render_term(E, Options)) || E <- Elements], ", "),
+     "}"];
+render_term(V, Options) when is_map(V) ->
+    Sorted = lists:sort(maps:to_list(V)),
+    ["#{",
+     string:join(
+       [lists:flatten([render_term(K, Options), " => ",
+                       render_term(Val, Options)])
+        || {K, Val} <- Sorted],
+       ", "),
+     "}"].
+
+render_atom(A, Options) ->
+    case proplists:get_value(atom_quoting, Options, loose) of
+        strict ->
+            io_lib:format("~p", [A]);
+        _ ->
+            atom_to_list(A)
+    end.
+
+render_string(S) ->
+    %% Escape backslash and double-quote so the output is unambiguous,
+    %% but leave other printable characters alone.
+    lists:flatten([escape_char(C) || C <- S]).
+
+escape_char($\\) -> "\\\\";
+escape_char($")  -> "\\\"";
+escape_char($\n) -> "\\n";
+escape_char($\r) -> "\\r";
+escape_char($\t) -> "\\t";
+escape_char(C)   -> [C].
+
+%% Walks the config and sorts nested proplists by key. This is what
+%% makes two equivalent outputs produce the same string regardless
+%% of original key order.
+canonicalise(Config) when is_list(Config) ->
+    Items = [canonicalise_top(I) || I <- Config],
+    lists:sort(Items).
+
+canonicalise_top({App, Settings}) when is_atom(App), is_list(Settings) ->
+    {App, sort_proplist(Settings)};
+canonicalise_top(Other) ->
+    Other.
+
+sort_proplist(L) when is_list(L) ->
+    Items = lists:map(fun sort_value/1, L),
+    lists:sort(fun compare_pairs/2, Items);
+sort_proplist(Other) -> Other.
+
+sort_value({K, V}) -> {K, walk(V)};
+sort_value(V) -> walk(V).
+
+walk(V) when is_list(V) ->
+    case looks_like_proplist(V) of
+        true  -> sort_proplist(V);
+        false -> [walk(E) || E <- V]
+    end;
+walk(V) when is_tuple(V) ->
+    list_to_tuple([walk(E) || E <- tuple_to_list(V)]);
+walk(V) when is_map(V) ->
+    maps:from_list([{K, walk(Val)} || {K, Val} <- maps:to_list(V)]);
+walk(Other) -> Other.
+
+%% Only re-sort a list when every element is a 2-tuple — a real
+%% proplist. A mixed list (including all-atom flag lists) keeps its
+%% original order, since reordering a TLS cipher list or a similar
+%% ordered collection would silently corrupt config semantics.
+looks_like_proplist([]) -> false;
+looks_like_proplist(L) ->
+    lists:all(fun({_, _}) -> true; (_) -> false end, L).
+
+compare_pairs({A, _}, {B, _}) -> A =< B;
+compare_pairs(A, B) -> A =< B.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -226,6 +226,33 @@ xlate({range_violation, {Value, {gt, Bound}}}) ->
     io_lib:format("~tp must be strictly greater than ~tp", [Value, Bound]);
 xlate({range_violation, {Value, {lt, Bound}}}) ->
     io_lib:format("~tp must be strictly less than ~tp", [Value, Bound]);
+xlate({constraint_validator_failed, Value}) ->
+    io_lib:format("~tp was rejected by a constraint-list validator",
+                  [Value]);
+xlate({constraint_validator_unresolved, Name}) ->
+    io_lib:format("Constraint-list validator '~ts' is not defined in any "
+                  "loaded schema", [Name]);
+xlate({validator_options_invalid, Name, Opts}) ->
+    io_lib:format("Validator ~ts has invalid options: ~tp "
+                  "(expected a proplist with {aliases, [_]} and/or "
+                  "{deprecated, Since, Hint})", [Name, Opts]);
+xlate({validator_alias_not_a_string, Name, Bad}) ->
+    io_lib:format("Validator ~ts has a non-string alias: ~tp",
+                  [Name, Bad]);
+xlate({validator_aliases_contain_duplicates, Name}) ->
+    io_lib:format("Validator ~ts has duplicate entries in its aliases list",
+                  [Name]);
+xlate({validator_alias_collision, Alias, Owner, Other}) ->
+    io_lib:format("Validator alias '~ts' is claimed by both '~ts' and '~ts'",
+                  [Alias, Owner, Other]);
+xlate({validator_alias_shadows_name, Alias, OwnerName}) ->
+    io_lib:format("Validator alias '~ts' on '~ts' shadows the canonical "
+                  "validator name of the same string",
+                  [Alias, OwnerName]);
+xlate({validator_deprecated_malformed, Name, Bad}) ->
+    io_lib:format("Validator ~ts has a malformed {deprecated, ...} option: "
+                  "~tp (expected {deprecated, SinceString, HintString})",
+                  [Name, Bad]);
 xlate({partial_app_not_loadable, App, {"no such file or directory", _}}) ->
     io_lib:format("Could not load OTP application '~ts' to resolve "
                   "partial: its .app file is not on the code path. "

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -106,14 +106,19 @@ map_value_sub(Schema, Config, ParsedArgs) ->
 -spec map_transform_datatypes(cuttlefish_schema:schema(), cuttlefish_conf:conf(), [proplists:property()]) ->
                                      [proplists:property()] |
                                      {error, atom(), cuttlefish_error:errorlist()}.
-map_transform_datatypes({_, Mappings, _} = Schema, DConfig, ParsedArgs) ->
+map_transform_datatypes({_, Mappings0, Validators} = Schema, DConfig, ParsedArgs) ->
     %% Everything in DConfig is of datatype "string",
     %% transform_datatypes turns them into other erlang terms
     %% based on the schema
     _ = ?LOG_DEBUG("Applying Datatypes"),
+    %% Resolve `{validator, Name}' entries inside constraint lists to
+    %% `{validator, Fun}' before datatype conversion runs, so the
+    %% conversion pass never has to consult the validator table.
+    Mappings = resolve_constraint_validators_in_mappings(Mappings0, Validators),
+    Schema1 = setelement(2, Schema, Mappings),
     case transform_datatypes(DConfig, Mappings, ParsedArgs) of
         {NewConf, []} ->
-            map_validate(Schema, NewConf);
+            map_validate(Schema1, NewConf);
         {_, EList} ->
             {error, transform_datatypes, {errorlist, EList}}
     end.
@@ -742,10 +747,14 @@ find_mapping(Variable, Mappings) ->
 -spec run_validations(cuttlefish_schema:schema(), cuttlefish_conf:conf())
     -> boolean()|list(cuttlefish_error:error()).
 run_validations({_, Mappings, Validators}, Conf) ->
+    %% Fresh per-pipeline warned-set: a validator's deprecation hint
+    %% fires once per load cycle, no matter how many call sites use it.
+    clear_deprecation_warned(),
     Validations = lists:flatten([ begin
         Vs = cuttlefish_mapping:validators(M, Validators),
         Value = proplists:get_value(cuttlefish_mapping:variable(M), Conf),
         [ begin
+            warn_if_deprecated(V, M),
             Validator = cuttlefish_validator:func(V),
             case {Value, Validator(Value)} of
                 {undefined, _} -> true;
@@ -768,6 +777,66 @@ run_validations({_, Mappings, Validators}, Conf) ->
     case lists:all(fun(X) -> X =:= true end, Validations) of
         true -> true;
         _ -> Validations
+    end.
+
+%% Build a name->Fun lookup, then rewrite each mapping's datatype so
+%% downstream stages see only resolved `{validator, Fun}' entries.
+-spec resolve_constraint_validators_in_mappings(
+        [cuttlefish_mapping:mapping()],
+        [cuttlefish_validator:validator()]) ->
+    [cuttlefish_mapping:mapping()].
+resolve_constraint_validators_in_mappings(Mappings, Validators) ->
+    Lookup = fun(Name) -> lookup_validator_fun(Name, Validators) end,
+    [ begin
+          DT = cuttlefish_mapping:datatype(M),
+          NewDT = cuttlefish_datatypes:resolve_constraint_validators(DT, Lookup),
+          cuttlefish_mapping:set_datatype(M, NewDT)
+      end || M <- Mappings ].
+
+%% Canonical name wins over alias: a validator declared with the
+%% same string as another's alias resolves to the canonical owner.
+lookup_validator_fun(Name, Validators) ->
+    case lists:search(
+           fun(V) -> cuttlefish_validator:name(V) =:= Name end,
+           Validators) of
+        {value, V} -> {ok, cuttlefish_validator:func(V)};
+        false ->
+            case lists:search(
+                   fun(V) -> lists:member(Name, cuttlefish_validator:aliases(V)) end,
+                   Validators) of
+                {value, V} -> {ok, cuttlefish_validator:func(V)};
+                false      -> not_found
+            end
+    end.
+
+-define(DEPRECATION_WARNED_KEY, {?MODULE, deprecation_warned}).
+
+clear_deprecation_warned() ->
+    erase(?DEPRECATION_WARNED_KEY),
+    ok.
+
+warn_if_deprecated(Validator, Mapping) ->
+    case cuttlefish_validator:deprecated(Validator) of
+        undefined -> ok;
+        {Since, Hint} ->
+            Name = cuttlefish_validator:name(Validator),
+            Warned = case get(?DEPRECATION_WARNED_KEY) of
+                undefined -> sets:new();
+                S         -> S
+            end,
+            case sets:is_element(Name, Warned) of
+                true -> ok;
+                false ->
+                    Var = cuttlefish_variable:format(
+                            cuttlefish_mapping:variable(Mapping)),
+                    Msg = io_lib:format(
+                        "Validator '~ts' is marked deprecated as of ~ts: "
+                        "~ts (first observed on mapping ~ts)",
+                        [Name, Since, Hint, Var]),
+                    cuttlefish:warn(lists:flatten(Msg)),
+                    put(?DEPRECATION_WARNED_KEY, sets:add_element(Name, Warned)),
+                    ok
+            end
     end.
 
 
@@ -806,16 +875,18 @@ validate(Schema, Config) ->
 
 -spec validate(cuttlefish_schema:schema(), cuttlefish_conf:conf(), [proplists:property()]) ->
     ok | {error, cuttlefish_error:errorlist()}.
-validate({_, Mappings, _} = Schema, Config, ParsedArgs) ->
-    AliasResolvedConfig = resolve_aliases(Config, Mappings),
-    DConfig = add_defaults(AliasResolvedConfig, Mappings),
+validate({_, Mappings0, Validators} = Schema0, Config, ParsedArgs) ->
+    AliasResolvedConfig = resolve_aliases(Config, Mappings0),
+    DConfig = add_defaults(AliasResolvedConfig, Mappings0),
     %% Separate errors injected by add_defaults from valid config entries so
     %% subsequent phases can still run.
     {DefaultErrors, CleanDConfig} = lists:partition(fun cuttlefish_error:is_error/1, DConfig),
     {SubbedConfig, SubErrors0} = value_sub(CleanDConfig),
-    SubErrors = enrich_alias_sub_errors(SubErrors0, Mappings),
+    SubErrors = enrich_alias_sub_errors(SubErrors0, Mappings0),
     %% transform_datatypes already returns {GoodConf, Errors}; in map/3 the
     %% error path discards GoodConf, but here we use both.
+    Mappings = resolve_constraint_validators_in_mappings(Mappings0, Validators),
+    Schema = setelement(2, Schema0, Mappings),
     {TypedConf, TypeErrors} = transform_datatypes(SubbedConfig, Mappings, ParsedArgs),
     ValidationErrors = case cuttlefish_error:errorlist_maybe(run_validations(Schema, TypedConf)) of
         {errorlist, EList} -> EList;

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -63,6 +63,7 @@
     has_default/1,
     commented/1,
     datatype/1,
+    set_datatype/2,
     level/1,
     hidden/1,
     doc/1,
@@ -322,6 +323,12 @@ commented(M)        -> M#mapping.commented.
 -spec datatype(mapping()) -> cuttlefish_datatypes:datatype_list().
 datatype(M) -> M#mapping.datatype.
 
+%% Pipeline-internal: swaps the datatype list in place so a later
+%% stage can substitute resolved `{validator, Fun}' for the parsed
+%% `{validator, Name}' entries. Not intended for schema authors.
+-spec set_datatype(mapping(), cuttlefish_datatypes:datatype_list()) -> mapping().
+set_datatype(M, DT) -> M#mapping{datatype = DT}.
+
 -spec level(mapping()) -> basic | intermediate | advanced.
 level(M) -> M#mapping.level.
 
@@ -356,11 +363,28 @@ collect(M) -> M#mapping.collect.
 -spec validators(mapping(), [cuttlefish_validator:validator()]) -> [cuttlefish_validator:validator()].
 validators(M, Validators) ->
     lists:foldr(fun(VName, Vs) ->
-                        case lists:keyfind(VName, 2, Validators) of
+                        case find_validator(VName, Validators) of
                             false -> Vs;
                             V -> [V|Vs]
                         end
                 end, [], M#mapping.validators).
+
+%% Look up by canonical name first, then by alias. Canonical match
+%% wins so a validator named "X" beats an alias "X" on a different
+%% validator — the same precedence rule mapping aliases use.
+find_validator(Name, Validators) ->
+    case lists:keyfind(Name, 2, Validators) of
+        false ->
+            find_by_alias(Name, Validators);
+        V -> V
+    end.
+
+find_by_alias(_Name, []) -> false;
+find_by_alias(Name, [V | Rest]) ->
+    case lists:member(Name, cuttlefish_validator:aliases(V)) of
+        true  -> V;
+        false -> find_by_alias(Name, Rest)
+    end.
 
 -spec replace(mapping(), [mapping()]) -> [mapping()].
 replace(Mapping, ListOfMappings) ->

--- a/src/cuttlefish_partial.erl
+++ b/src/cuttlefish_partial.erl
@@ -38,12 +38,16 @@
 -type partial_term() ::
         {mapping, string(), string(), [proplists:property()]}
       | {validator, string(), string(), fun((term()) -> boolean())}
+      | {validator, string(), string(), fun((term()) -> boolean()),
+         [proplists:property()]}
       | {partial_translation, string(),
          fun((cuttlefish_conf:conf(), string(), string()) -> term())}.
 
 -type emitted_term() ::
         {mapping, string(), string(), [proplists:property()]}
       | {validator, string(), string(), fun((term()) -> boolean())}
+      | {validator, string(), string(), fun((term()) -> boolean()),
+         [proplists:property()]}
       | {translation, string(),
          fun((cuttlefish_conf:conf()) -> term())}.
 
@@ -354,6 +358,8 @@ sanitize(App, Name, [{mapping, _, _, Opts} | Rest]) when is_list(Opts) ->
     sanitize(App, Name, Rest);
 sanitize(App, Name, [{validator, _, _, _} | Rest]) ->
     sanitize(App, Name, Rest);
+sanitize(App, Name, [{validator, _, _, _, _} | Rest]) ->
+    sanitize(App, Name, Rest);
 sanitize(App, Name, [{partial_translation, _, _} | Rest]) ->
     sanitize(App, Name, Rest);
 sanitize(_App, _Name, [{translation, _, _} | _]) ->
@@ -395,6 +401,8 @@ rewrite_term({mapping, ConfKey, AppKey, Opts}, Prefix, AppPrefix, Exclude, Overr
                   NewOpts}}
     end;
 rewrite_term({validator, _, _, _} = V, _Prefix, _AppPrefix, _Exclude, _Overrides) ->
+    {ok, V};
+rewrite_term({validator, _, _, _, _} = V, _Prefix, _AppPrefix, _Exclude, _Overrides) ->
     {ok, V};
 rewrite_term({partial_translation, BareKey, Fun}, Prefix, AppPrefix, Exclude, _Overrides) ->
     case excluded(BareKey, Exclude) of

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -112,7 +112,8 @@ list_schemas(Dir) ->
 -spec filter(schema() | cuttlefish_error:errorlist()) -> schema() | cuttlefish_error:errorlist().
 filter({errorlist, Errorlist}) ->
     {errorlist, Errorlist};
-filter({Translations, Mappings, Validators}) ->
+filter({Translations, Mappings, Validators0}) ->
+    Validators = inject_builtin_validators(Mappings, Validators0),
     Counts = count_mappings(Mappings),
     {MappingsToCheck, _} = lists:unzip(Counts),
     NewMappings = lists:foldl(
@@ -129,13 +130,161 @@ filter({Translations, Mappings, Validators}) ->
 
     case validate_aliases(NewMappings) of
         ok ->
-            case validate_validator_refs(NewMappings, Validators) of
-                ok -> {Translations, NewMappings, Validators};
+            case validate_validator_aliases(Validators) of
+                ok ->
+                    case validate_validator_refs(NewMappings, Validators) of
+                        ok -> {Translations, NewMappings, Validators};
+                        {errorlist, _} = Errors -> Errors
+                    end;
                 {errorlist, _} = Errors -> Errors
             end;
         {errorlist, _} = Errors ->
             Errors
     end.
+
+%% A small set of built-in validators is shipped with cuttlefish so
+%% schemas can refer to widely-used names — `"port"', `"byte"',
+%% `"valid_regex"', `"uri"' — without having to declare them in-tree.
+%% A user definition with the same name wins (the user is already in
+%% `Validators'); the builtin is only added when no such name is
+%% defined yet.
+%%
+%% `"port"' and `"byte"' delegate to the matching datatype.
+%% `"valid_regex"' delegates to the `regex' datatype.
+%% `"uri"' is a no-op marker validator with a deprecation hint
+%% pointing at the stricter `uri' datatype.
+-spec inject_builtin_validators(
+        [cuttlefish_mapping:mapping()],
+        [cuttlefish_validator:validator()]) ->
+    [cuttlefish_validator:validator()].
+inject_builtin_validators(Mappings, Validators) ->
+    %% Only inject a builtin whose name is actually referenced
+    %% somewhere in the schema — keeps the validator list unchanged
+    %% for schemas that don't use these names. When the name is
+    %% already taken (user-defined or previously injected), do
+    %% nothing silently: the deprecation hint on the builtin is the
+    %% channel for nudging the migration, not a per-load shadow
+    %% warning that fires every time a schema author chooses to keep
+    %% their local definition.
+    Referenced = referenced_validator_names(Mappings),
+    lists:foldl(
+        fun(Raw, Acc) ->
+            Name = builtin_name(Raw),
+            case sets:is_element(Name, Referenced)
+                 andalso not is_name_taken(Raw, Acc) of
+                true ->
+                    case cuttlefish_validator:parse(Raw) of
+                        {error, _} -> Acc;
+                        V -> [V | Acc]
+                    end;
+                false -> Acc
+            end
+        end, Validators, builtin_validator_specs()).
+
+%% Builtin specs all use the 5-tuple form (they carry a deprecation
+%% hint), so a single clause is enough.
+builtin_name({validator, Name, _, _, _}) -> Name.
+
+referenced_validator_names(Mappings) ->
+    Names = lists:flatmap(
+        fun(M) ->
+            DT = cuttlefish_mapping:datatype(M),
+            cuttlefish_mapping:validators(M)
+                ++ cuttlefish_datatypes:constraint_validator_refs(DT)
+        end, Mappings),
+    sets:from_list(Names).
+
+%% Taken if some already-parsed validator has the same canonical
+%% name OR carries the name as one of its aliases.
+is_name_taken({validator, Name, _, _, _}, Validators) ->
+    lists:any(
+      fun(V) -> cuttlefish_validator:matches_name(Name, V) end,
+      Validators).
+
+builtin_validator_specs() ->
+    [
+     %% Mechanically equivalent to a hand-written `>=0 && =<255'.
+     {validator, "byte", "0..255",
+      fun(V) ->
+          case cuttlefish_datatypes:from_string(V, byte) of
+              {error, _} -> false;
+              _          -> true
+          end
+      end,
+      [{deprecated, "3.9.0",
+        "use the {datatype, byte} form instead"}]},
+     %% Accepts the full 0..65535 IANA range; some schemas use a
+     %% stricter predicate and will see a shift in accepted values
+     %% if they switch to this builtin.
+     {validator, "port", "0..65535",
+      fun(V) ->
+          case cuttlefish_datatypes:from_string(V, port) of
+              {error, _} -> false;
+              _          -> true
+          end
+      end,
+      [{deprecated, "3.9.0",
+        "use the {datatype, port} form instead "
+        "(accepts the full 0..65535 IANA range)"}]},
+     %% Rejects empty patterns and patterns prone to catastrophic
+     %% backtracking; this is stricter than a plain re:compile/1.
+     {validator, "valid_regex", "compilable regular expression",
+      fun(V) ->
+          case cuttlefish_datatypes:from_string(V, regex) of
+              {error, _} -> false;
+              _          -> true
+          end
+      end,
+      [{deprecated, "3.9.0",
+        "use the {datatype, regex} form instead "
+        "(also rejects patterns prone to catastrophic backtracking)"}]},
+     %% No-op marker so call sites whose values are templates,
+     %% placeholders, or otherwise not strictly parseable as URIs
+     %% keep working without each schema having to declare its own
+     %% trivial `"uri"' validator.
+     {validator, "uri",
+      "URI-shaped string; structural validation deferred to application code",
+      fun(_) -> true end,
+      [{deprecated, "3.9.0",
+        "for structural URI validation, use {datatype, uri} "
+        "or {datatype, {uri, [Schemes]}} instead"}]}
+    ].
+
+%% Mirror the per-mapping alias collision rules for validators:
+%% reject aliases that shadow another validator's canonical name and
+%% reject the same alias appearing on two different validators.
+-spec validate_validator_aliases([cuttlefish_validator:validator()]) ->
+    ok | cuttlefish_error:errorlist().
+validate_validator_aliases(Validators) ->
+    Names = [cuttlefish_validator:name(V) || V <- Validators],
+    NameSet = sets:from_list(Names),
+    AliasIndex = lists:flatmap(
+        fun(V) ->
+            Name = cuttlefish_validator:name(V),
+            [{A, Name} || A <- cuttlefish_validator:aliases(V)]
+        end, Validators),
+    Errors = collect_validator_alias_errors(AliasIndex, NameSet, []),
+    case Errors of
+        [] -> ok;
+        _  -> {errorlist, lists:reverse(Errors)}
+    end.
+
+collect_validator_alias_errors([], _NameSet, Errors) -> Errors;
+collect_validator_alias_errors([{Alias, OwnerName} | Rest], NameSet, Errors) ->
+    NewErrors = case sets:is_element(Alias, NameSet) andalso Alias =/= OwnerName of
+        true ->
+            [{error, {validator_alias_shadows_name, Alias, OwnerName}}
+             | Errors];
+        false ->
+            Other = lists:keyfind(Alias, 1, Rest),
+            case Other of
+                {Alias, OtherOwner} when OtherOwner =/= OwnerName ->
+                    [{error, {validator_alias_collision, Alias, OwnerName, OtherOwner}}
+                     | Errors];
+                _ -> Errors
+            end
+    end,
+    collect_validator_alias_errors(Rest, NameSet, NewErrors).
 
 %% @doc Checks that every validator name referenced by a mapping's
 %% `{validators, [...]}` opt resolves to a defined validator.
@@ -147,12 +296,22 @@ filter({Translations, Mappings, Validators}) ->
     ok | cuttlefish_error:errorlist().
 validate_validator_refs(Mappings, Validators) ->
     Defined = sets:from_list(
-        [cuttlefish_validator:name(V) || V <- Validators]),
+        lists:flatmap(
+          fun(V) ->
+              [cuttlefish_validator:name(V) | cuttlefish_validator:aliases(V)]
+          end, Validators)),
     Missing = lists:flatmap(
         fun(M) ->
             Var = cuttlefish_variable:format(cuttlefish_mapping:variable(M)),
-            [{Var, N} || N <- cuttlefish_mapping:validators(M),
-                         not sets:is_element(N, Defined)]
+            FromValidators = [{Var, N}
+                              || N <- cuttlefish_mapping:validators(M),
+                                 not sets:is_element(N, Defined)],
+            DT = cuttlefish_mapping:datatype(M),
+            FromConstraints =
+                [{Var, N}
+                 || N <- cuttlefish_datatypes:constraint_validator_refs(DT),
+                    not sets:is_element(N, Defined)],
+            FromValidators ++ FromConstraints
         end, Mappings),
     case Missing of
         [] -> ok;
@@ -377,7 +536,19 @@ parse_schema(ScannedTokens, CommentTokens, {TAcc, MAcc, VAcc, EAcc}) ->
         {translation, Return} ->
             {cuttlefish_translation:parse_and_merge(Return, TAcc), MAcc, VAcc, EAcc};
         {validator, Return} ->
-            {TAcc, MAcc, cuttlefish_validator:parse_and_merge(Return, VAcc), EAcc};
+            %% Pre-flight the parse so a malformed validator surfaces
+            %% as an error rather than getting silently dropped. Code
+            %% later in the pipeline accesses validator record fields
+            %% and would crash if an `{error, _}' slipped into the
+            %% validators list.
+            case cuttlefish_validator:parse(Return) of
+                {error, _} = E ->
+                    {TAcc, MAcc, VAcc, [E | EAcc]};
+                _ ->
+                    {TAcc, MAcc,
+                     cuttlefish_validator:parse_and_merge(Return, VAcc),
+                     EAcc}
+            end;
         {include_partial, {include_partial, {App, Name}, IncludeOpts}}
                 when is_atom(App), is_list(Name), is_list(IncludeOpts) ->
             apply_partial(App, Name, IncludeOpts, {TAcc, MAcc, VAcc, EAcc});
@@ -417,9 +588,21 @@ annotate_partial_source(Other, _App, _Name) ->
 apply_partial_term({mapping, _, _, _} = Raw, {T, M, V, E}) ->
     {T, cuttlefish_mapping:parse_and_merge(Raw, M), V, E};
 apply_partial_term({validator, _, _, _} = Raw, {T, M, V, E}) ->
-    {T, M, cuttlefish_validator:parse_and_merge(Raw, V), E};
+    apply_validator_partial_term(Raw, T, M, V, E);
+apply_partial_term({validator, _, _, _, _} = Raw, {T, M, V, E}) ->
+    apply_validator_partial_term(Raw, T, M, V, E);
 apply_partial_term({translation, _, _} = Raw, {T, M, V, E}) ->
     {cuttlefish_translation:parse_and_merge(Raw, T), M, V, E}.
+
+%% Route parse errors to the error accumulator so they cannot
+%% corrupt the validators list.
+apply_validator_partial_term(Raw, T, M, V, E) ->
+    case cuttlefish_validator:parse(Raw) of
+        {error, _} = Err ->
+            {T, M, V, [Err | E]};
+        _ ->
+            {T, M, cuttlefish_validator:parse_and_merge(Raw, V), E}
+    end.
 
 parse_schema_tokens(Scanned) ->
     parse_schema_tokens(Scanned, []).

--- a/src/cuttlefish_validator.erl
+++ b/src/cuttlefish_validator.erl
@@ -21,18 +21,20 @@
 %% -------------------------------------------------------------------
 -module(cuttlefish_validator).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
 -record(validator, {
     name::string(),
     description::string(),
-    func::fun()
+    func::fun(),
+    aliases = [] :: [string()],
+    deprecated :: undefined | {string(), string()}
     }).
 -type validator() :: #validator{}.
 -type validator_fun() :: fun((any()) -> boolean()).
--type raw_validator() :: {validator, string(), string(), validator_fun()}.
+-type validator_opt() :: {aliases, [string()]}
+                       | {deprecated, string(), string()}.
+-type raw_validator() :: {validator, string(), string(), validator_fun()}
+                       | {validator, string(), string(), validator_fun(),
+                          [validator_opt()]}.
 -export_type([validator/0]).
 
 -export([
@@ -42,30 +44,102 @@
     name/1,
     description/1,
     func/1,
-    replace/2]).
+    aliases/1,
+    deprecated/1,
+    replace/2,
+    matches_name/2]).
 
 -spec parse(raw_validator()) -> validator() | cuttlefish_error:error().
 parse({validator, Name, Description, Fun}) ->
-    #validator{
-        name = Name,
-        description = Description,
-        func = Fun
-    };
+    #validator{name = Name, description = Description, func = Fun};
+parse({validator, Name, Description, Fun, Opts}) when is_list(Opts) ->
+    case parse_opts(Name, Opts) of
+        {error, _} = E -> E;
+        {Aliases, Deprecated} ->
+            #validator{name = Name,
+                       description = Description,
+                       func = Fun,
+                       aliases = Aliases,
+                       deprecated = Deprecated}
+    end;
+parse({validator, Name, _Description, _Fun, BadOpts}) ->
+    {error, {validator_options_invalid, Name, BadOpts}};
 parse(X) ->
     {error, {validator_parse, X}}.
 
-%% This assumes it's run as part of a foldl over new schema elements
-%% in which case, there's only ever one instance of a key in the list
-%% so keyreplace works fine.
--spec parse_and_merge(
-    raw_validator(), [validator()]) -> [validator()|cuttlefish_error:error()].
+%% Reject anything that isn't `aliases' or `deprecated' so a typo in
+%% the options proplist surfaces at parse time.
+parse_opts(Name, Opts) ->
+    case lists:partition(fun is_known_opt/1, Opts) of
+        {_, [Bad | _]} ->
+            {error, {validator_options_invalid, Name, Bad}};
+        {Known, []} ->
+            case extract_aliases(Name, Known) of
+                {error, _} = E -> E;
+                Aliases ->
+                    case extract_deprecated(Name, Known) of
+                        {error, _} = E -> E;
+                        Deprecated     -> {Aliases, Deprecated}
+                    end
+            end
+    end.
+
+is_known_opt({aliases, _})       -> true;
+is_known_opt({deprecated, _, _}) -> true;
+is_known_opt(_)                  -> false.
+
+extract_aliases(Name, Opts) ->
+    case proplists:get_value(aliases, Opts) of
+        undefined -> [];
+        [] -> [];
+        L when is_list(L) ->
+            case lists:all(fun erlang:is_list/1, L) of
+                true ->
+                    case length(lists:usort(L)) < length(L) of
+                        true  -> {error, {validator_aliases_contain_duplicates, Name}};
+                        false -> L
+                    end;
+                false ->
+                    Bad = hd([X || X <- L, not is_list(X)]),
+                    {error, {validator_alias_not_a_string, Name, Bad}}
+            end;
+        Bad -> {error, {validator_alias_not_a_string, Name, Bad}}
+    end.
+
+extract_deprecated(Name, Opts) ->
+    case [D || {deprecated, _, _} = D <- Opts] of
+        [] -> undefined;
+        [{deprecated, Since, Hint}] when is_list(Since), is_list(Hint) ->
+            {Since, Hint};
+        [Bad | _] ->
+            {error, {validator_deprecated_malformed, Name, Bad}}
+    end.
+
+%% Assumes a foldl over schema elements where each name appears at
+%% most once in `Validators', so a single keyreplace handles update.
+-spec parse_and_merge(raw_validator(), [validator()]) -> [validator()].
 parse_and_merge({validator, ValidatorName, _, _} = ValidatorSource, Validators) ->
-    NewValidator = parse(ValidatorSource),
-    case lists:keyfind(ValidatorName, #validator.name, Validators) of
-        false ->
-            [ NewValidator | Validators];
-        _OldMapping ->
-            lists:keyreplace(ValidatorName, #validator.name, Validators, NewValidator)
+    do_parse_and_merge(ValidatorName, ValidatorSource, Validators);
+parse_and_merge({validator, ValidatorName, _, _, _} = ValidatorSource, Validators) ->
+    do_parse_and_merge(ValidatorName, ValidatorSource, Validators).
+
+do_parse_and_merge(ValidatorName, ValidatorSource, Validators) ->
+    %% A parse error must not contaminate the validators list: code
+    %% later in the pipeline accesses record fields and would crash
+    %% on an `{error, _}' tuple. The schema parser surfaces the
+    %% failure through its own error accumulator; here we simply
+    %% leave the list unchanged.
+    case parse(ValidatorSource) of
+        {error, _} ->
+            Validators;
+        NewValidator ->
+            case lists:keyfind(ValidatorName, #validator.name, Validators) of
+                false ->
+                    [NewValidator | Validators];
+                _OldValidator ->
+                    lists:keyreplace(ValidatorName, #validator.name,
+                                     Validators, NewValidator)
+            end
     end.
 
 -spec is_validator(any()) -> boolean().
@@ -80,6 +154,17 @@ description(V) -> V#validator.description.
 -spec func(validator()) -> fun().
 func(V) -> V#validator.func.
 
+-spec aliases(validator()) -> [string()].
+aliases(V) -> V#validator.aliases.
+
+-spec deprecated(validator()) -> undefined | {string(), string()}.
+deprecated(V) -> V#validator.deprecated.
+
+%% True when `Name' is the canonical name or one of the aliases.
+-spec matches_name(string(), validator()) -> boolean().
+matches_name(Name, V) ->
+    Name =:= V#validator.name orelse lists:member(Name, V#validator.aliases).
+
 -spec replace(validator(), [validator()]) -> [validator()].
 replace(Validator, ListOfValidators) ->
     Exists = lists:keymember(name(Validator), #validator.name, ListOfValidators),
@@ -89,115 +174,3 @@ replace(Validator, ListOfValidators) ->
         _ ->
             [Validator | ListOfValidators]
     end.
-
--ifdef(TEST).
-
--define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
-
-parse_test() ->
-    ValidatorDataStruct = {
-        validator,
-        "name",
-        "description",
-        fun(X) -> X*2 end
-    },
-
-    Validator = parse(ValidatorDataStruct),
-
-    ?assertEqual("name", Validator#validator.name),
-    ?assertEqual("description", Validator#validator.description),
-    F = Validator#validator.func,
-    ?assertEqual(4, F(2)),
-    ok.
-
-
-getter_test() ->
-    Validator = #validator{
-        name = "name",
-        description = "description",
-        func = fun(X) -> X*2 end
-    },
-
-    ?assertEqual("name", name(Validator)),
-    ?assertEqual("description", description(Validator)),
-
-    Fun = func(Validator),
-    ?assertEqual(4, Fun(2)),
-    ok.
-
-
-replace_test() ->
-    Element1 = #validator{
-        name = "name18",
-        description = "description18",
-        func = fun(X) -> X*2 end
-    },
-    ?assertEqual(4, (Element1#validator.func)(2)),
-
-    Element2 = #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*4 end
-    },
-    ?assertEqual(8, (Element2#validator.func)(2)),
-
-    SampleValidators = [Element1, Element2],
-
-    Override = #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*5 end
-    },
-    ?assertEqual(25, (Override#validator.func)(5)),
-
-    NewValidators = replace(Override, SampleValidators),
-    ?assertEqual([Element1, Override], NewValidators),
-    ok.
-
-remove_duplicates_test() ->
-    Sample1 = #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*3 end
-    },
-    ?assertEqual(6, (Sample1#validator.func)(2)),
-
-    Sample2 = #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*4 end
-    },
-    ?assertEqual(8, (Sample2#validator.func)(2)),
-
-    SampleValidators = [Sample1, Sample2],
-
-    [NewValidator|_] = parse_and_merge(
-        {validator, "name1", "description2", fun(X) -> X*10 end},
-        SampleValidators),
-    F = func(NewValidator),
-    ?assertEqual(50, F(5)),
-    ?assertEqual("description2", description(NewValidator)),
-    ?assertEqual("name1", name(NewValidator)),
-    ok.
-
-parse_error_test() ->
-    {ErrorAtom, ErrorTerm} = parse(not_a_raw_validator),
-    ?assertEqual(error, ErrorAtom),
-    ?assertEqual(
-        "Poorly formatted input to cuttlefish_validator:parse/1 : not_a_raw_validator",
-        ?XLATE(ErrorTerm)),
-    ok.
-
-is_validator_test() ->
-    ?assert(not(is_validator(not_a_validator))),
-
-    V = #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*4 end
-    },
-    ?assertEqual(8, (V#validator.func)(2)),
-    ?assert(is_validator(V)),
-    ok.
-
--endif.

--- a/test/cuttlefish_allow_infinity_tests.erl
+++ b/test/cuttlefish_allow_infinity_tests.erl
@@ -1,0 +1,84 @@
+-module(cuttlefish_allow_infinity_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(cuttlefish_datatypes, [from_string/2, is_supported/1]).
+
+%% A constraint list with `allow_infinity' accepts the atom or the
+%% string `"infinity"' as a valid value. Other inputs still go
+%% through the regular numeric pipeline.
+
+is_supported_with_allow_infinity_test() ->
+    ?assert(is_supported({integer, [allow_infinity]})),
+    ?assert(is_supported({integer, [non_negative, allow_infinity]})),
+    ?assert(is_supported({integer, [{min, 1}, {max, 65535}, allow_infinity]})),
+    ?assert(is_supported({float, [allow_infinity]})),
+    ?assert(is_supported({float, [{min, 0.0}, allow_infinity]})).
+
+integer_accepts_infinity_string_test() ->
+    ?assertEqual(infinity,
+                 from_string("infinity",
+                             {integer, [non_negative, allow_infinity]})).
+
+integer_accepts_infinity_atom_test() ->
+    %% Defaults may flow through as atoms; the parser should accept
+    %% that shape as well as the string form.
+    ?assertEqual(infinity,
+                 from_string(infinity,
+                             {integer, [{min, 1}, allow_infinity]})).
+
+integer_accepts_numeric_values_alongside_infinity_test() ->
+    DT = {integer, [non_negative, allow_infinity]},
+    ?assertEqual(0, from_string("0", DT)),
+    ?assertEqual(7, from_string("7", DT)).
+
+integer_rejects_negative_when_only_non_negative_test() ->
+    %% Negative input still goes through the constraint pipeline.
+    DT = {integer, [non_negative, allow_infinity]},
+    ?assertMatch({error, {range_violation, _}}, from_string("-1", DT)).
+
+integer_rejects_unknown_strings_test() ->
+    DT = {integer, [allow_infinity]},
+    ?assertMatch({error, {conversion, _}}, from_string("forever", DT)).
+
+float_accepts_infinity_test() ->
+    DT = {float, [{min, 0.0}, allow_infinity]},
+    ?assertEqual(infinity, from_string("infinity", DT)),
+    ?assertEqual(0.5, from_string("0.5", DT)).
+
+bytesize_accepts_infinity_test() ->
+    DT = {bytesize, [non_negative, allow_infinity]},
+    ?assertEqual(infinity, from_string("infinity", DT)),
+    ?assertEqual(1024, from_string("1KB", DT)).
+
+duration_accepts_infinity_test() ->
+    DT = {duration, ms, [non_negative, allow_infinity]},
+    ?assertEqual(infinity, from_string("infinity", DT)),
+    ?assertEqual(5000, from_string("5s", DT)).
+
+without_allow_infinity_string_is_rejected_test() ->
+    %% Sanity: without the shortcut, "infinity" is a parse error.
+    ?assertMatch({error, {conversion, _}},
+                 from_string("infinity", {integer, [non_negative]})).
+
+infinity_does_not_bypass_other_validators_when_value_is_numeric_test() ->
+    %% A numeric value still satisfies the surrounding constraints.
+    DT = {integer, [{min, 1}, {max, 100}, allow_infinity]},
+    ?assertMatch({error, {range_violation, {0, {min, 1}}}}, from_string("0", DT)).
+
+infinity_to_string_round_trips_test() ->
+    %% Regression: `to_string(infinity, {integer, [...]})' must
+    %% produce `infinity', not fall through into the integer
+    %% clauses where the atom would not be accepted.
+    ?assertEqual("infinity",
+                 cuttlefish_datatypes:to_string(
+                   infinity, {integer, [non_negative, allow_infinity]})),
+    ?assertEqual("infinity",
+                 cuttlefish_datatypes:to_string(
+                   infinity, {float, [{min, 0.0}, allow_infinity]})),
+    ?assertEqual("infinity",
+                 cuttlefish_datatypes:to_string(
+                   infinity, {bytesize, [non_negative, allow_infinity]})),
+    ?assertEqual("infinity",
+                 cuttlefish_datatypes:to_string(
+                   infinity, {duration, ms, [non_negative, allow_infinity]})).

--- a/test/cuttlefish_builtin_validators_tests.erl
+++ b/test/cuttlefish_builtin_validators_tests.erl
@@ -1,0 +1,176 @@
+-module(cuttlefish_builtin_validators_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Built-in validators delegate to the matching datatype. They are
+%% injected lazily — only when the schema references them.
+
+byte_builtin_passes_in_range_test() ->
+    %% Boundary values: 0 and 255 are both accepted.
+    Schema =
+        "{mapping, \"max\", \"app.max\","
+        "  [{datatype, integer}, {validators, [\"byte\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{max, 0}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["max"], "0"}])),
+    ?assertEqual([{app, [{max, 255}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["max"], "255"}])).
+
+byte_builtin_rejects_out_of_range_test() ->
+    Schema =
+        "{mapping, \"max\", \"app.max\","
+        "  [{datatype, integer}, {validators, [\"byte\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["max"], "300"}],
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V}, Conf)).
+
+port_builtin_passes_test() ->
+    %% Boundary values: 0 (OS-assigned semantics) and 65535 are both
+    %% accepted by the IANA-range port datatype the builtin delegates
+    %% to. A schema that wants stricter behaviour declares its own
+    %% predicate, which then wins via shadowing.
+    Schema =
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{p, 0}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["p"], "0"}])),
+    ?assertEqual([{app, [{p, 5672}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["p"], "5672"}])),
+    ?assertEqual([{app, [{p, 65535}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["p"], "65535"}])).
+
+port_builtin_rejects_overshoot_test() ->
+    Schema =
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V}, [{["p"], "999999"}])).
+
+valid_regex_builtin_accepts_compilable_test() ->
+    Schema =
+        "{mapping, \"pat\", \"app.pat\","
+        "  [{datatype, string}, {validators, [\"valid_regex\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{pat, "^[a-z]+$"}]}],
+                 cuttlefish_generator:map({T, M, V},
+                                          [{["pat"], "^[a-z]+$"}])).
+
+valid_regex_builtin_rejects_uncompilable_test() ->
+    Schema =
+        "{mapping, \"pat\", \"app.pat\","
+        "  [{datatype, string}, {validators, [\"valid_regex\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    %% Unclosed paren is uncompilable.
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V},
+                                          [{["pat"], "(unclosed"}])).
+
+user_defined_with_same_name_wins_test() ->
+    %% A user-defined `"port"' validator that only accepts 1..1024
+    %% should win over the builtin.
+    Schema =
+        "{validator, \"port\", \"strict port\","
+        "  fun(N) -> is_integer(N) andalso N >= 1 andalso N =< 1024 end}.\n"
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    %% 5672 is allowed by the builtin (0..65535) but not the user
+    %% predicate (1..1024). Validation must fail using the user
+    %% definition.
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V}, [{["p"], "5672"}])).
+
+builtins_not_injected_when_not_referenced_test() ->
+    %% A schema that doesn't mention these names should keep its
+    %% validator list unchanged (count = 0 here).
+    Schema =
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}]}.\n",
+    {_, _, Validators} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual(0, length(Validators)).
+
+deprecation_hint_on_injected_builtin_fires_test() ->
+    %% When a schema references a builtin and no local definition
+    %% shadows it, the builtin's deprecation hint emits one warn
+    %% line on the first call site within a pipeline run.
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    _ = cuttlefish_generator:map({T, M, V}, [{["p"], "5672"}]),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Lines = [L || L <- Logs, string:find(L, "port") =/= nomatch,
+                  string:find(L, "deprecated") =/= nomatch],
+    ?assertEqual(1, length(Lines)).
+
+shadow_keeps_builtin_deprecation_silent_test() ->
+    %% Conversely, when the local validator wins, the builtin's
+    %% deprecation hint must NOT fire — the runtime never reaches
+    %% the builtin.
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{validator, \"port\", \"strict\","
+        "  fun(N) -> is_integer(N) andalso N > 0 andalso N < 65535 end}.\n"
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    _ = cuttlefish_generator:map({T, M, V}, [{["p"], "5672"}]),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Lines = [L || L <- Logs, string:find(L, "deprecated") =/= nomatch],
+    ?assertEqual(0, length(Lines)).
+
+shadow_is_silent_test() ->
+    %% A user `port' definition wins and silently overrides the
+    %% builtin: no shadow warning, the operator's local predicate is
+    %% intentional and the deprecation hint on the builtin (which
+    %% only fires when the builtin is the one running) is the
+    %% intended channel for nudging the migration.
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{validator, \"port\", \"strict\","
+        "  fun(N) -> is_integer(N) andalso N >= 1 andalso N =< 1024 end}.\n"
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    _ = cuttlefish_schema:strings([Schema]),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Shadow = [L || L <- Logs, string:find(L, "shadow") =/= nomatch],
+    ?assertEqual(0, length(Shadow)).
+
+valid_regex_builtin_rejects_empty_test() ->
+    Schema =
+        "{mapping, \"pat\", \"app.pat\","
+        "  [{datatype, string}, {validators, [\"valid_regex\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V},
+                                          [{["pat"], ""}])).
+
+byte_builtin_rejects_negative_test() ->
+    Schema =
+        "{mapping, \"max\", \"app.max\","
+        "  [{datatype, integer}, {validators, [\"byte\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V},
+                                          [{["max"], "-1"}])).
+
+builtin_resolved_when_referenced_from_constraint_list_test() ->
+    %% A builtin can be referenced from inside a constraint list
+    %% (e.g. `{integer, [{validator, "byte"}]}'), the injection
+    %% sees the reference and the resolution path uses the
+    %% builtin's func.
+    Schema =
+        "{mapping, \"max\", \"app.max\","
+        "  [{datatype, {integer, [{validator, \"byte\"}]}}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{max, 200}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["max"], "200"}])),
+    ?assertMatch({error, transform_datatypes, _},
+                 cuttlefish_generator:map({T, M, V}, [{["max"], "300"}])).

--- a/test/cuttlefish_bytesize_duration_constraints_tests.erl
+++ b/test/cuttlefish_bytesize_duration_constraints_tests.erl
@@ -1,0 +1,68 @@
+-module(cuttlefish_bytesize_duration_constraints_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(cuttlefish_datatypes, [from_string/2, to_string/2, is_supported/1]).
+
+%% bytesize range constraints
+
+bytesize_with_constraints_is_supported_test() ->
+    ?assert(is_supported({bytesize, [{min, 0}, {max, 1024}]})),
+    ?assert(is_supported({bytesize, non_negative})),
+    ?assert(is_supported({bytesize, positive})).
+
+bytesize_rejects_invalid_constraints_test() ->
+    ?assertNot(is_supported({bytesize, [{min, "zero"}]})),
+    ?assertNot(is_supported({bytesize, [{nonsense, 1}]})).
+
+bytesize_accepts_in_range_test() ->
+    DT = {bytesize, [{min, 0}, {max, 1048576}]},
+    ?assertEqual(1024, from_string("1KB", DT)),
+    ?assertEqual(0, from_string("0", DT)).
+
+bytesize_rejects_below_min_test() ->
+    %% bytesize parses into an integer count of bytes; the bound
+    %% applies to that count.
+    DT = {bytesize, [{min, 1024}]},
+    ?assertMatch({error, {range_violation, {512, {min, 1024}}}},
+                 from_string("512", DT)).
+
+bytesize_rejects_above_max_test() ->
+    DT = {bytesize, [{max, 1024}]},
+    ?assertMatch({error, {range_violation, {2048, {max, 1024}}}},
+                 from_string("2KB", DT)).
+
+bytesize_to_string_passes_through_test() ->
+    DT = {bytesize, [{min, 0}]},
+    ?assertEqual("1GB", to_string(1073741824, DT)).
+
+%% duration range constraints
+
+duration_with_constraints_is_supported_test() ->
+    ?assert(is_supported({duration, ms, [{min, 0}, {max, 60000}]})),
+    ?assert(is_supported({duration, s, non_negative})),
+    ?assert(is_supported({duration, h, positive})).
+
+duration_rejects_bad_unit_test() ->
+    ?assertNot(is_supported({duration, year, [{min, 0}]})).
+
+duration_accepts_in_range_test() ->
+    DT = {duration, ms, [{min, 0}, {max, 60000}]},
+    ?assertEqual(1000, from_string("1s", DT)),
+    ?assertEqual(60000, from_string("1m", DT)).
+
+duration_rejects_below_min_test() ->
+    DT = {duration, ms, [{min, 1000}]},
+    ?assertMatch({error, {range_violation, {500, {min, 1000}}}},
+                 from_string("500ms", DT)).
+
+duration_rejects_above_max_test() ->
+    DT = {duration, s, [{max, 60}]},
+    ?assertMatch({error, {range_violation, {120, {max, 60}}}},
+                 from_string("2m", DT)).
+
+duration_to_string_passes_through_test() ->
+    %% to_string preserves the bare-duration semantics for the new
+    %% three-tuple form.
+    DT = {duration, s, [{min, 0}]},
+    ?assertEqual("1w", to_string("1w", DT)).

--- a/test/cuttlefish_combined_features_tests.erl
+++ b/test/cuttlefish_combined_features_tests.erl
@@ -1,0 +1,49 @@
+-module(cuttlefish_combined_features_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% End-to-end exercise of the constraint/validator/diff additions
+%% working together. The schema below uses bytesize and duration
+%% range constraints, an `allow_infinity' shortcut, a constraint-list
+%% validator entry by name, a 5-tuple validator with aliases and a
+%% deprecation hint, the built-in `byte' validator, and the built-in
+%% `uri' marker. The result is then rendered with `cuttlefish_diff'.
+
+every_feature_combined_test() ->
+    Schema =
+        "{validator, \"even\", \"even integer\","
+        "  fun(N) when is_integer(N) -> N rem 2 =:= 0 end,"
+        "  [{aliases, [\"even_legacy\"]}]}.\n"
+        "{mapping, \"buffer.bytes\", \"app.buf\","
+        "  [{datatype, {bytesize, [{min, 1}, {max, 1073741824}]}}]}.\n"
+        "{mapping, \"poll.interval\", \"app.poll\","
+        "  [{datatype, {duration, ms, [non_negative, allow_infinity]}}]}.\n"
+        "{mapping, \"max_age\", \"app.max\","
+        "  [{datatype, integer},"
+        "   {validators, [\"byte\"]}]}.\n"
+        "{mapping, \"webhook\", \"app.hook\","
+        "  [{datatype, string}, {validators, [\"uri\"]}]}.\n"
+        "{mapping, \"batch.size\", \"app.batch\","
+        "  [{datatype, {integer, [{min, 2}, {validator, \"even_legacy\"}]}}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [
+        {["buffer", "bytes"], "10MB"},
+        {["poll", "interval"], "infinity"},
+        {["max_age"], "200"},
+        {["webhook"], "https://{{node}}/notify"},
+        {["batch", "size"], "8"}
+    ],
+    Result = cuttlefish_generator:map({T, M, V}, Conf),
+    ?assertMatch([{app, _}], Result),
+    [{app, AppCfg}] = Result,
+    Sorted = lists:sort(AppCfg),
+    ?assertEqual(8, proplists:get_value(batch, Sorted)),
+    ?assertEqual(10485760, proplists:get_value(buf, Sorted)),
+    ?assertEqual("https://{{node}}/notify", proplists:get_value(hook, Sorted)),
+    ?assertEqual(200, proplists:get_value(max, Sorted)),
+    ?assertEqual(infinity, proplists:get_value(poll, Sorted)),
+    %% Idempotent rendering: two runs over the same input produce the
+    %% same string.
+    Out1 = lists:flatten(cuttlefish_diff:render_normalised(Result)),
+    Out2 = lists:flatten(cuttlefish_diff:render_normalised(Result)),
+    ?assertEqual(Out1, Out2).

--- a/test/cuttlefish_constraint_features_proper_tests.erl
+++ b/test/cuttlefish_constraint_features_proper_tests.erl
@@ -1,0 +1,100 @@
+-module(cuttlefish_constraint_features_proper_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PROP(P), ?assert(proper:quickcheck(P, [{numtests, 200}, {to_file, user}]))).
+
+%% Property-based coverage for `allow_infinity', bytesize and
+%% duration range constraints, constraint-list validators, and the
+%% normalised diff renderer.
+
+allow_infinity_idempotent_test() -> ?PROP(prop_allow_infinity_idempotent()).
+allow_infinity_numeric_path_test() -> ?PROP(prop_allow_infinity_numeric_path()).
+bytesize_constraint_round_trip_test() -> ?PROP(prop_bytesize_constraint()).
+duration_constraint_round_trip_test() -> ?PROP(prop_duration_constraint()).
+constraint_validator_first_failure_wins_test() ->
+    ?PROP(prop_first_failure_wins()).
+render_normalised_stable_under_permutation_test() ->
+    ?PROP(prop_render_stable_under_permutation()).
+
+%% For any integer N and any constraint set that includes
+%% `allow_infinity', parsing `"infinity"' yields the atom `infinity'.
+prop_allow_infinity_idempotent() ->
+    ?FORALL(Extra, list(constraint_atom()),
+        cuttlefish_datatypes:from_string("infinity",
+            {integer, [allow_infinity | Extra]}) =:= infinity).
+
+%% For a non-negative integer string `N', conversion through a
+%% non_negative constraint with allow_infinity returns the same
+%% integer that the bare integer datatype would return.
+prop_allow_infinity_numeric_path() ->
+    ?FORALL(N, non_neg_integer(),
+        cuttlefish_datatypes:from_string(integer_to_list(N),
+            {integer, [non_negative, allow_infinity]}) =:= N).
+
+%% A bytesize value in a wide range round-trips: parse, ensure the
+%% parsed value falls inside `[Min, Max]'.
+prop_bytesize_constraint() ->
+    ?FORALL(N, choose(0, 1073741824),
+        begin
+            Parsed = cuttlefish_datatypes:from_string(
+                       integer_to_list(N),
+                       {bytesize, [{min, 0}, {max, 1073741824}]}),
+            is_integer(Parsed) andalso Parsed =:= N
+        end).
+
+%% A duration in milliseconds round-trips with bounds.
+prop_duration_constraint() ->
+    ?FORALL(N, choose(0, 60000),
+        begin
+            Parsed = cuttlefish_datatypes:from_string(
+                       integer_to_list(N) ++ "ms",
+                       {duration, ms, [{min, 0}, {max, 60000}]}),
+            is_integer(Parsed) andalso Parsed >= 0 andalso Parsed =< 60000
+        end).
+
+%% Two constraints — first rejects all, second accepts all — must
+%% report failure attributable to the first one (constraint order is
+%% left-to-right).
+prop_first_failure_wins() ->
+    ?FORALL(N, non_neg_integer(),
+        begin
+            DT = {integer, [{validator, fun(_) -> false end},
+                            {validator, fun(_) -> true end}]},
+            Result = cuttlefish_datatypes:from_string(integer_to_list(N), DT),
+            case Result of
+                {error, {constraint_validator_failed, _}} -> true;
+                _ -> false
+            end
+        end).
+
+%% Permuting the order of `{app, ...}' top-level entries and the
+%% order of inner key/value pairs does not change the rendered form.
+prop_render_stable_under_permutation() ->
+    ?FORALL({Keys, Values}, {non_empty(list(atom_key())),
+                              non_empty(list(simple_value()))},
+        begin
+            %% Build a small but non-empty proplist
+            Pairs = lists:zip(
+                      lists:sublist(Keys, length(Values)),
+                      lists:sublist(Values, length(Keys))),
+            %% Drop duplicate keys
+            Unique = lists:ukeysort(1, Pairs),
+            Config = [{app, Unique}],
+            Shuffled = [{app, lists:reverse(Unique)}],
+            A = lists:flatten(cuttlefish_diff:render_normalised(Config)),
+            B = lists:flatten(cuttlefish_diff:render_normalised(Shuffled)),
+            A =:= B
+        end).
+
+%%% Generators
+
+constraint_atom() ->
+    oneof([non_negative, positive]).
+
+atom_key() ->
+    elements([alpha, beta, gamma, delta, epsilon, zeta]).
+
+simple_value() ->
+    oneof([integer(), atom(), boolean()]).

--- a/test/cuttlefish_constraint_validator_tests.erl
+++ b/test/cuttlefish_constraint_validator_tests.erl
@@ -1,0 +1,139 @@
+-module(cuttlefish_constraint_validator_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(cuttlefish_datatypes, [from_string/2, is_supported/1]).
+
+%% Validator entries inside a constraint list. Two forms are
+%% accepted: `{validator, Fun}' is applied directly at conversion
+%% time; `{validator, Name}' is resolved against the loaded
+%% validator set before datatype conversion runs.
+
+is_supported_with_fun_validator_test() ->
+    F = fun(N) when is_integer(N) -> N rem 2 =:= 0 end,
+    ?assert(is_supported({integer, [{validator, F}]})),
+    ?assert(is_supported({integer, [{min, 0}, {validator, F}, {max, 100}]})).
+
+is_supported_with_named_validator_test() ->
+    ?assert(is_supported({integer, [{validator, "power_of_two"}]})).
+
+fun_validator_passes_value_through_test() ->
+    DT = {integer, [{min, 1}, {validator, fun(N) -> N rem 2 =:= 0 end}]},
+    ?assertEqual(8, from_string("8", DT)),
+    ?assertEqual(2, from_string("2", DT)).
+
+fun_validator_rejects_failing_value_test() ->
+    DT = {integer, [{validator, fun(N) -> N rem 2 =:= 0 end}]},
+    ?assertMatch({error, {constraint_validator_failed, 3}}, from_string("3", DT)).
+
+fun_validator_runs_left_to_right_first_failure_wins_test() ->
+    %% The range constraint fires before the validator, so a value
+    %% that fails the range never reaches the validator.
+    DT = {integer, [{min, 1}, {validator, fun(_) -> true end}]},
+    ?assertMatch({error, {range_violation, {0, {min, 1}}}}, from_string("0", DT)).
+
+fun_validator_exceptions_count_as_failure_test() ->
+    DT = {integer, [{validator, fun(_) -> error(boom) end}]},
+    ?assertMatch({error, {constraint_validator_failed, _}}, from_string("1", DT)).
+
+named_validator_unresolved_at_runtime_is_an_error_test() ->
+    %% If a name slips through schema validation and reaches
+    %% conversion unresolved, the runtime surfaces it rather than
+    %% silently accepting the value.
+    DT = {integer, [{validator, "not_resolved"}]},
+    ?assertMatch({error, {constraint_validator_unresolved, "not_resolved"}},
+                 from_string("1", DT)).
+
+%% End-to-end through the schema pipeline.
+
+named_validator_in_constraint_list_resolves_test() ->
+    Schema =
+        "{validator, \"power_of_two\", \"a power of two\","
+        "  fun(N) when is_integer(N) ->"
+        "    N > 0 andalso (N band (N - 1)) =:= 0"
+        "  end}.\n"
+        "{mapping, \"queue.max_size\", \"app.qmax\","
+        "  [{datatype, {integer, [{min, 1}, {validator, \"power_of_two\"}]}}]}.\n",
+    {Translations, Mappings, Validators} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["queue", "max_size"], "16"}],
+    Result = cuttlefish_generator:map(
+               {Translations, Mappings, Validators}, Conf),
+    ?assertEqual([{app, [{qmax, 16}]}], Result).
+
+named_validator_in_constraint_rejects_bad_value_test() ->
+    Schema =
+        "{validator, \"power_of_two\", \"a power of two\","
+        "  fun(N) when is_integer(N) ->"
+        "    N > 0 andalso (N band (N - 1)) =:= 0"
+        "  end}.\n"
+        "{mapping, \"queue.max_size\", \"app.qmax\","
+        "  [{datatype, {integer, [{min, 1}, {validator, \"power_of_two\"}]}}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["queue", "max_size"], "5"}],
+    ?assertMatch({error, transform_datatypes, _},
+                 cuttlefish_generator:map({T, M, V}, Conf)).
+
+undefined_named_validator_in_constraint_is_pre_flight_error_test() ->
+    Schema =
+        "{mapping, \"queue.max_size\", \"app.qmax\","
+        "  [{datatype, {integer, [{validator, \"never_defined\"}]}}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist,
+                  [{error, {validator_not_defined, "queue.max_size",
+                            "never_defined"}}]},
+                 Result).
+
+%% Nested datatypes — `{list, {integer, [{validator, Name}]}}'.
+%% The name lookup must recurse into the inner datatype.
+nested_list_resolves_named_validator_test() ->
+    Schema =
+        "{validator, \"even\", \"even integer\","
+        "  fun(N) -> is_integer(N) andalso N rem 2 =:= 0 end}.\n"
+        "{mapping, \"vals\", \"app.vals\","
+        "  [{datatype, {list, {integer, [{validator, \"even\"}]}}}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["vals"], "2, 4, 6"}],
+    ?assertEqual([{app, [{vals, [2, 4, 6]}]}],
+                 cuttlefish_generator:map({T, M, V}, Conf)).
+
+nested_list_undefined_name_is_pre_flight_error_test() ->
+    Schema =
+        "{mapping, \"vals\", \"app.vals\","
+        "  [{datatype, {list, {integer, [{validator, \"missing\"}]}}}]}.\n",
+    ?assertMatch({errorlist,
+                  [{error, {validator_not_defined, "vals", "missing"}}]},
+                 cuttlefish_schema:strings([Schema])).
+
+multiple_validators_run_in_order_test() ->
+    %% Two anonymous validators: first rejects everything > 100,
+    %% second rejects odd numbers. A value 99 passes the first but
+    %% fails the second.
+    DT = {integer, [{validator, fun(N) -> N =< 100 end},
+                    {validator, fun(N) -> N rem 2 =:= 0 end}]},
+    ?assertEqual(2, cuttlefish_datatypes:from_string("2", DT)),
+    ?assertMatch({error, {constraint_validator_failed, 99}},
+                 cuttlefish_datatypes:from_string("99", DT)),
+    ?assertMatch({error, {constraint_validator_failed, 101}},
+                 cuttlefish_datatypes:from_string("101", DT)).
+
+constraint_list_can_reference_validator_by_alias_test() ->
+    Schema =
+        "{validator, \"even\", \"even\","
+        "  fun(N) -> is_integer(N) andalso N rem 2 =:= 0 end,"
+        "  [{aliases, [\"evens\"]}]}.\n"
+        "{mapping, \"n\", \"app.n\","
+        "  [{datatype, {integer, [{validator, \"evens\"}]}}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{n, 4}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["n"], "4"}])),
+    ?assertMatch({error, transform_datatypes, _},
+                 cuttlefish_generator:map({T, M, V}, [{["n"], "3"}])).
+
+allow_infinity_skips_validator_test() ->
+    %% When the bypass fires, the constraint pipeline (including
+    %% validators) does not run on the atom `infinity'. The
+    %% intent is for infinity to be a *valid* value regardless of
+    %% the other constraints.
+    DT = {integer, [allow_infinity,
+                    {validator, fun(_) -> false end}]},
+    ?assertEqual(infinity, cuttlefish_datatypes:from_string("infinity", DT)).

--- a/test/cuttlefish_diff_tests.erl
+++ b/test/cuttlefish_diff_tests.erl
@@ -1,0 +1,115 @@
+-module(cuttlefish_diff_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(cuttlefish_diff, [render_normalised/1, render_normalised/2]).
+
+-define(LINES(IOData), string:split(lists:flatten(IOData), "\n", all)).
+
+empty_config_renders_empty_test() ->
+    ?assertEqual([], lists:flatten(render_normalised([]))).
+
+single_app_section_renders_test() ->
+    Out = lists:flatten(render_normalised([{app, [{key, "value"}]}])),
+    ?assert(string:find(Out, "app =>") =/= nomatch),
+    ?assert(string:find(Out, "key = \"value\"") =/= nomatch).
+
+%% Two equivalent configs that differ only by key order produce the
+%% same rendered output.
+key_order_does_not_affect_output_test() ->
+    A = [{app, [{a, 1}, {b, 2}, {c, 3}]}],
+    B = [{app, [{c, 3}, {b, 2}, {a, 1}]}],
+    ?assertEqual(lists:flatten(render_normalised(A)),
+                 lists:flatten(render_normalised(B))).
+
+%% Two configs that differ in a single value produce different
+%% renderings.
+value_change_visible_in_output_test() ->
+    A = [{app, [{port, 5672}]}],
+    B = [{app, [{port, 5673}]}],
+    ?assertNotEqual(lists:flatten(render_normalised(A)),
+                    lists:flatten(render_normalised(B))).
+
+funs_are_stable_under_skip_funs_test() ->
+    F1 = fun(X) -> X end,
+    F2 = fun(Y) -> Y * 2 end,
+    A = [{app, [{handler, F1}]}],
+    B = [{app, [{handler, F2}]}],
+    %% Different funs collapse to the same `#Fun<>' placeholder.
+    ?assertEqual(lists:flatten(render_normalised(A, [{skip_funs, true}])),
+                 lists:flatten(render_normalised(B, [{skip_funs, true}]))).
+
+atom_quoting_default_is_loose_test() ->
+    Out = lists:flatten(render_normalised([{app, [{key, hello}]}])),
+    ?assert(string:find(Out, "key = hello") =/= nomatch).
+
+atom_quoting_strict_quotes_special_atoms_test() ->
+    %% An atom with a hyphen requires Erlang quoting; strict mode
+    %% surfaces that, loose mode does not.
+    Special = 'with-dashes',
+    Strict = lists:flatten(render_normalised([{app, [{k, Special}]}],
+                                             [{atom_quoting, strict}])),
+    Loose  = lists:flatten(render_normalised([{app, [{k, Special}]}])),
+    ?assert(string:find(Strict, "'with-dashes'") =/= nomatch),
+    ?assert(string:find(Loose,  "with-dashes") =/= nomatch),
+    ?assertEqual(nomatch, string:find(Loose, "'with-dashes'")).
+
+binary_distinguished_from_string_test() ->
+    Bin = lists:flatten(render_normalised([{app, [{k, <<"hi">>}]}])),
+    Str = lists:flatten(render_normalised([{app, [{k, "hi"}]}])),
+    ?assertNotEqual(Bin, Str).
+
+deeply_nested_proplist_is_sorted_test() ->
+    A = [{app, [{group, [{z, 1}, {a, 2}]}]}],
+    B = [{app, [{group, [{a, 2}, {z, 1}]}]}],
+    ?assertEqual(lists:flatten(render_normalised(A)),
+                 lists:flatten(render_normalised(B))).
+
+bare_atom_list_order_preserved_test() ->
+    %% A list of atoms (e.g. TLS cipher preferences) is order-bearing.
+    %% Two inputs with different orders must render differently.
+    A = [{app, [{ciphers, [tls1, tls2, tls3]}]}],
+    B = [{app, [{ciphers, [tls3, tls2, tls1]}]}],
+    ?assertNotEqual(lists:flatten(render_normalised(A)),
+                    lists:flatten(render_normalised(B))).
+
+multiple_app_sections_render_in_sorted_order_test() ->
+    %% Top-level entries are sorted alphabetically by app name,
+    %% making the multi-app diff layout stable.
+    A = [{zeta, [{k, 1}]}, {alpha, [{k, 2}]}, {gamma, [{k, 3}]}],
+    Out = lists:flatten(render_normalised(A)),
+    AlphaPos = string:str(Out, "alpha"),
+    GammaPos = string:str(Out, "gamma"),
+    ZetaPos  = string:str(Out, "zeta"),
+    ?assert(AlphaPos > 0 andalso GammaPos > 0 andalso ZetaPos > 0),
+    ?assert(AlphaPos < GammaPos),
+    ?assert(GammaPos < ZetaPos).
+
+skip_funs_false_emits_more_detail_test() ->
+    %% With `{skip_funs, false}', a fun renders via `~p' instead of
+    %% the fixed `#Fun<>' placeholder, so the output is longer.
+    F = fun erlang:length/1,
+    Stable = lists:flatten(render_normalised([{app, [{k, F}]}],
+                                             [{skip_funs, true}])),
+    Detailed = lists:flatten(render_normalised([{app, [{k, F}]}],
+                                               [{skip_funs, false}])),
+    ?assert(length(Detailed) > length(Stable)).
+
+nested_map_value_renders_test() ->
+    %% Maps land in app.config via translations and must render
+    %% without crashing.
+    Out = lists:flatten(render_normalised(
+                          [{app, [{flags, #{a => 1, b => 2}}]}])),
+    ?assert(string:find(Out, "#{") =/= nomatch),
+    ?assert(string:find(Out, "=>") =/= nomatch).
+
+real_pipeline_idempotent_under_render_test() ->
+    %% Two runs of the same schema/conf produce identical output.
+    Schema =
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}, {default, 7}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf1 = cuttlefish_generator:map({T, M, V}, [{["x"], "42"}]),
+    Conf2 = cuttlefish_generator:map({T, M, V}, [{["x"], "42"}]),
+    ?assertEqual(lists:flatten(render_normalised(Conf1)),
+                 lists:flatten(render_normalised(Conf2))).

--- a/test/cuttlefish_partial_integration_tests.erl
+++ b/test/cuttlefish_partial_integration_tests.erl
@@ -214,6 +214,28 @@ full_pipeline_with_included_partial_produces_expected_app_config_test() ->
     ?assertEqual(lists:sort(['tlsv1.2', 'tlsv1.3']),
                  lists:sort(Versions)).
 
+partial_with_5_tuple_validator_loads_and_runs_test() ->
+    %% A partial containing a 5-tuple validator (with aliases and a
+    %% deprecation hint) must pass sanitize, survive rewrite, and
+    %% land in the merged validator set with its options intact.
+    add_fixture_path(),
+    Schema =
+        "{include_partial, {sample_app, \"with_5_tuple_validator\"},\n"
+        "    [{prefix, \"p\"}, {app_prefix, \"a\"}]}.\n",
+    {_T, Mappings, Validators} = cuttlefish_schema:strings([Schema]),
+    [V] = Validators,
+    ?assertEqual("even", cuttlefish_validator:name(V)),
+    ?assertEqual(["evens"], cuttlefish_validator:aliases(V)),
+    ?assertMatch({"3.9.0", _}, cuttlefish_validator:deprecated(V)),
+    ?assertEqual(1, length(Mappings)),
+    %% The validator actually fires through the pipeline.
+    ?assertMatch([{a, [{n, 4}]}],
+                 cuttlefish_generator:map(
+                   {_T, Mappings, Validators}, [{["p", "n"], "4"}])),
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map(
+                   {_T, Mappings, Validators}, [{["p", "n"], "5"}])).
+
 full_pipeline_applies_partial_defaults_test() ->
     %% A partial mapping with `{default, _}` contributes that default
     %% to the consumer's app.config when the conf is silent.

--- a/test/cuttlefish_partial_tests.erl
+++ b/test/cuttlefish_partial_tests.erl
@@ -62,6 +62,16 @@ validator_passes_through_unchanged_test() ->
     {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
     ?assertEqual(Term, Out).
 
+validator_5_tuple_passes_through_unchanged_test() ->
+    %% A validator declared with an options proplist (aliases,
+    %% deprecation hint) survives partial rewriting unchanged.
+    Fun = fun(_) -> true end,
+    Term = {validator, "pem_file", "must be a PEM file", Fun,
+            [{aliases, ["pem"]},
+             {deprecated, "3.9.0", "use the {datatype, file} form"}]},
+    {ok, [Out]} = cuttlefish_partial:rewrite([Term], ?BASE_OPTS),
+    ?assertEqual(Term, Out).
+
 partial_translation_emits_arity1_closure_with_bound_prefixes_test() ->
     Term = {partial_translation, "versions",
             fun(C, P, A) -> {C, P, A} end},

--- a/test/cuttlefish_uri_marker_tests.erl
+++ b/test/cuttlefish_uri_marker_tests.erl
@@ -1,0 +1,41 @@
+-module(cuttlefish_uri_marker_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The `"uri"' marker validator ships as a no-op, so a schema that
+%% historically declared an inline no-op `"uri"' validator can drop
+%% the local definition without rewriting call sites.
+
+uri_marker_accepts_anything_test() ->
+    Schema =
+        "{mapping, \"u\", \"app.u\","
+        "  [{datatype, string}, {validators, [\"uri\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    %% Template-style values that the strict `uri' datatype would
+    %% reject still pass the marker.
+    Conf = [{["u"], "https://{{node}}/health"}],
+    ?assertEqual([{app, [{u, "https://{{node}}/health"}]}],
+                 cuttlefish_generator:map({T, M, V}, Conf)).
+
+uri_marker_accepts_empty_string_test() ->
+    Schema =
+        "{mapping, \"u\", \"app.u\","
+        "  [{datatype, string}, {validators, [\"uri\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertEqual([{app, [{u, ""}]}],
+                 cuttlefish_generator:map({T, M, V}, [{["u"], ""}])).
+
+user_defined_uri_validator_wins_test() ->
+    %% A user-defined `"uri"' that's actually strict beats the marker.
+    Schema =
+        "{validator, \"uri\", \"must start with https://\","
+        "  fun(S) -> case S of"
+        "    \"https://\" ++ _ -> true;"
+        "    _ -> false"
+        "  end end}.\n"
+        "{mapping, \"u\", \"app.u\","
+        "  [{datatype, string}, {validators, [\"uri\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({error, validation, _},
+                 cuttlefish_generator:map({T, M, V},
+                                          [{["u"], "http://example.com"}])).

--- a/test/cuttlefish_validator_aliases_tests.erl
+++ b/test/cuttlefish_validator_aliases_tests.erl
@@ -1,0 +1,118 @@
+-module(cuttlefish_validator_aliases_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
+
+%% Per-validator aliases: rename a validator without breaking
+%% existing call sites.
+
+parse_with_aliases_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "new", "desc", fun(_) -> true end,
+           [{aliases, ["old", "older"]}]}),
+    ?assertEqual("new", cuttlefish_validator:name(V)),
+    ?assertEqual(["old", "older"], cuttlefish_validator:aliases(V)).
+
+parse_without_aliases_defaults_to_empty_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "name", "desc", fun(_) -> true end}),
+    ?assertEqual([], cuttlefish_validator:aliases(V)).
+
+parse_empty_aliases_is_accepted_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "name", "desc", fun(_) -> true end,
+           [{aliases, []}]}),
+    ?assertEqual([], cuttlefish_validator:aliases(V)).
+
+parse_non_string_alias_is_rejected_test() ->
+    Result = cuttlefish_validator:parse(
+               {validator, "name", "desc", fun(_) -> true end,
+                [{aliases, [42]}]}),
+    ?assertMatch({error, {validator_alias_not_a_string, "name", 42}}, Result).
+
+parse_duplicate_aliases_are_rejected_test() ->
+    Result = cuttlefish_validator:parse(
+               {validator, "name", "desc", fun(_) -> true end,
+                [{aliases, ["a", "a"]}]}),
+    ?assertMatch({error, {validator_aliases_contain_duplicates, "name"}},
+                 Result).
+
+matches_name_via_canonical_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "new", "d", fun(_) -> true end, [{aliases, ["old"]}]}),
+    ?assert(cuttlefish_validator:matches_name("new", V)),
+    ?assert(cuttlefish_validator:matches_name("old", V)),
+    ?assertNot(cuttlefish_validator:matches_name("other", V)).
+
+mapping_finds_validator_by_alias_test() ->
+    Schema =
+        "{validator, \"new\", \"desc\","
+        "  fun(N) -> N > 0 end,"
+        "  [{aliases, [\"old\"]}]}.\n"
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}, {validators, [\"old\"]}]}.\n",
+    {_, [M], [V]} = cuttlefish_schema:strings([Schema]),
+    [Found] = cuttlefish_mapping:validators(M, [V]),
+    ?assertEqual("new", cuttlefish_validator:name(Found)).
+
+canonical_wins_over_alias_when_both_present_test() ->
+    %% Both validators load successfully (their canonical names
+    %% don't collide and the alias "old" doesn't collide either).
+    %% The lookup must return the canonical "old" definition, not
+    %% the one that lists "old" as an alias.
+    Schema =
+        "{validator, \"old\", \"canonical\","
+        "  fun(_) -> a end}.\n"
+        "{validator, \"replacement\", \"newer\","
+        "  fun(_) -> b end,"
+        "  [{aliases, [\"old_other\"]}]}.\n"
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}, {validators, [\"old\"]}]}.\n",
+    {_, [M], Validators} = cuttlefish_schema:strings([Schema]),
+    [Found] = cuttlefish_mapping:validators(M, Validators),
+    ?assertEqual("old", cuttlefish_validator:name(Found)).
+
+alias_collision_between_validators_is_rejected_test() ->
+    Schema =
+        "{validator, \"a\", \"d\", fun(_) -> true end,"
+        "  [{aliases, [\"shared\"]}]}.\n"
+        "{validator, \"b\", \"d\", fun(_) -> true end,"
+        "  [{aliases, [\"shared\"]}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist,
+                  [{error, {validator_alias_collision, "shared", _, _}}]},
+                 Result).
+
+alias_shadowing_canonical_name_is_rejected_test() ->
+    Schema =
+        "{validator, \"x\", \"d\", fun(_) -> true end}.\n"
+        "{validator, \"y\", \"d\", fun(_) -> true end,"
+        "  [{aliases, [\"x\"]}]}.\n",
+    Result = cuttlefish_schema:strings([Schema]),
+    ?assertMatch({errorlist,
+                  [{error, {validator_alias_shadows_name, "x", "y"}}]},
+                 Result).
+
+xlate_validator_alias_collision_test() ->
+    Msg = ?XLATE({validator_alias_collision, "shared", "a", "b"}),
+    ?assert(string:find(Msg, "shared") =/= nomatch),
+    ?assert(string:find(Msg, "a") =/= nomatch),
+    ?assert(string:find(Msg, "b") =/= nomatch).
+
+user_alias_matching_builtin_name_suppresses_injection_test() ->
+    %% A user validator with alias "port" should answer to "port"
+    %% references AND prevent the builtin from being injected. This
+    %% is consistent with `matches_name/2' precedence.
+    Schema =
+        "{validator, \"strict_port\", \"my strict\","
+        "  fun(N) -> N >= 1024 andalso N =< 49151 end,"
+        "  [{aliases, [\"port\"]}]}.\n"
+        "{mapping, \"p\", \"app.p\","
+        "  [{datatype, integer}, {validators, [\"port\"]}]}.\n",
+    {_, [M], V} = cuttlefish_schema:strings([Schema]),
+    [Found] = cuttlefish_mapping:validators(M, V),
+    ?assertEqual("strict_port", cuttlefish_validator:name(Found)),
+    %% The builtin must NOT have been added — the user's "strict_port"
+    %% is the only validator in the list.
+    ?assertEqual(1, length(V)).

--- a/test/cuttlefish_validator_deprecation_tests.erl
+++ b/test/cuttlefish_validator_deprecation_tests.erl
@@ -1,0 +1,106 @@
+-module(cuttlefish_validator_deprecation_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Deprecation hints on validator definitions surface as a single
+%% warn line per validator name per load cycle.
+
+parse_with_deprecation_hint_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "old", "d", fun(_) -> true end,
+           [{deprecated, "3.9.0", "use the new form"}]}),
+    ?assertEqual({"3.9.0", "use the new form"},
+                 cuttlefish_validator:deprecated(V)).
+
+parse_without_hint_defaults_to_undefined_test() ->
+    V = cuttlefish_validator:parse(
+          {validator, "x", "d", fun(_) -> true end}),
+    ?assertEqual(undefined, cuttlefish_validator:deprecated(V)).
+
+%% A malformed deprecation hint inside a schema file must surface
+%% as a clean errorlist — never as an uncaught exception in the
+%% downstream filter pipeline. (Regression guard against a bug
+%% where the error tuple polluted the validators list and broke
+%% record-field access in validate_validator_aliases/1.)
+malformed_options_in_schema_surfaces_as_errorlist_test() ->
+    Schema =
+        "{validator, \"x\", \"d\", fun(_) -> true end,"
+        "  [{deprecated, not_a_string, \"hint\"}]}.\n"
+        "{mapping, \"k\", \"app.k\","
+        "  [{datatype, integer}, {validators, [\"x\"]}]}.\n",
+    Result = try cuttlefish_schema:strings([Schema])
+             catch C:E -> {caught, C, E}
+             end,
+    ?assertMatch({errorlist, [_|_]}, Result),
+    {errorlist, Es} = Result,
+    ?assert(lists:any(
+        fun({error, {validator_deprecated_malformed, "x", _}}) -> true;
+           (_) -> false
+        end, Es)).
+
+parse_malformed_deprecation_hint_is_rejected_test() ->
+    Bad = cuttlefish_validator:parse(
+            {validator, "x", "d", fun(_) -> true end,
+             [{deprecated, not_a_string, "hint"}]}),
+    ?assertMatch({error, {validator_deprecated_malformed, "x", _}}, Bad).
+
+unknown_option_is_rejected_test() ->
+    Result = cuttlefish_validator:parse(
+               {validator, "x", "d", fun(_) -> true end,
+                [{not_an_option, ok}]}),
+    ?assertMatch({error, {validator_options_invalid, "x", _}}, Result).
+
+warning_emitted_on_first_use_test() ->
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{validator, \"old_check\", \"a check\","
+        "  fun(N) -> N > 0 end,"
+        "  [{deprecated, \"3.9.0\", \"use {integer, positive}\"}]}.\n"
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}, {validators, [\"old_check\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["x"], "5"}],
+    _ = cuttlefish_generator:map({T, M, V}, Conf),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Mentions = [L || L <- Logs,
+                     string:find(L, "old_check") =/= nomatch,
+                     string:find(L, "deprecated") =/= nomatch],
+    ?assertEqual(1, length(Mentions)).
+
+deprecation_warning_includes_hint_text_test() ->
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{validator, \"old_check\", \"a check\","
+        "  fun(N) -> N > 0 end,"
+        "  [{deprecated, \"3.9.0\", \"use {integer, positive} datatype\"}]}.\n"
+        "{mapping, \"x\", \"app.x\","
+        "  [{datatype, integer}, {validators, [\"old_check\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    _ = cuttlefish_generator:map({T, M, V}, [{["x"], "5"}]),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Mentions = [L || L <- Logs, string:find(L, "old_check") =/= nomatch],
+    [Line | _] = Mentions,
+    ?assert(string:find(Line, "use {integer, positive} datatype") =/= nomatch),
+    ?assert(string:find(Line, "3.9.0") =/= nomatch).
+
+warning_emitted_at_most_once_per_load_test() ->
+    %% Two mappings both pointing at the same deprecated validator,
+    %% one map call: exactly one warn is expected.
+    _ = cuttlefish_test_logging:set_up(),
+    _ = cuttlefish_test_logging:bounce(warning),
+    Schema =
+        "{validator, \"old_check\", \"a check\","
+        "  fun(N) -> N > 0 end,"
+        "  [{deprecated, \"3.9.0\", \"hint\"}]}.\n"
+        "{mapping, \"a\", \"app.a\","
+        "  [{datatype, integer}, {validators, [\"old_check\"]}]}.\n"
+        "{mapping, \"b\", \"app.b\","
+        "  [{datatype, integer}, {validators, [\"old_check\"]}]}.\n",
+    {T, M, V} = cuttlefish_schema:strings([Schema]),
+    Conf = [{["a"], "5"}, {["b"], "10"}],
+    _ = cuttlefish_generator:map({T, M, V}, Conf),
+    Logs = [lists:flatten(L) || L <- cuttlefish_test_logging:get_logs()],
+    Mentions = [L || L <- Logs, string:find(L, "old_check") =/= nomatch],
+    ?assertEqual(1, length(Mentions)).

--- a/test/fixtures/sample_app/priv/schema/with_5_tuple_validator.partial
+++ b/test/fixtures/sample_app/priv/schema/with_5_tuple_validator.partial
@@ -1,0 +1,9 @@
+%% Exercises a 5-tuple validator declaration with both `aliases' and
+%% `deprecated' options.
+
+{validator, "even", "even integer",
+ fun(N) -> is_integer(N) andalso N rem 2 =:= 0 end,
+ [{aliases, ["evens"]},
+  {deprecated, "3.9.0", "use {integer, [{validator, fun ...}]} instead"}]}.
+
+{mapping, "n", "n", [{datatype, integer}, {validators, ["even"]}]}.


### PR DESCRIPTION
These smaller improvements are additional follow-up after some experimental, yet-to-be made public schema file refactorings in RabbitMQ.

Using the duplicate patterns, I could identify a few relatively small incremental improvements over what was shipped in `3.9.0`.